### PR TITLE
Implements Cut unnecessary OR transformation

### DIFF
--- a/reduct/boolean-reduct/cut-unnecessary-or.metta
+++ b/reduct/boolean-reduct/cut-unnecessary-or.metta
@@ -1,0 +1,35 @@
+ ;(: orCut (-> Expression Expression))
+ ; orCut transformation
+ ;;   - applied when OR node has single child
+ ;;;        - returns guardset of child expression and grandchildren
+ ;;   - if starting node isn't an OR node will return the expression itself
+ ;;;        - (AND A B)
+ ;;;        - ( A B)
+ ; Example
+ ;;  (OR (AND (NOT D) C)) ->((NOT D) C)
+ ;;  (OR A) -> A
+
+( = (orCut $expresion)
+    (if  (== $expresion ()) ()
+        ( let  $type (get-metatype $expresion)
+             ; Check if what is passed in is a symbol/Literal and not an expression
+            (if (== $type Symbol)
+                $expresion
+                (let* (
+                        ($head (car-atom $expresion))
+                        ($tail (cdr-atom $expresion))
+                        ($subhead (car-atom $tail))
+                        ($subtail (cdr-atom $tail))
+                    ) (if ( and (== $head OR) (== $subtail ()))
+                    (if ( == Symbol (get-metatype $subhead))
+                        ($subhead) ; To make sure to always return Expression instead of Symbol
+                        (let*
+                            (
+                                ( ($guardSet $children) (getGsetAndChildren  (car-atom $tail)))
+                            )
+                        (concatTuple $guardSet $children)
+                    )
+
+            )
+        $expresion)))))
+)

--- a/reduct/boolean-reduct/tests/cut-unnecessary-or-test.metta
+++ b/reduct/boolean-reduct/tests/cut-unnecessary-or-test.metta
@@ -1,0 +1,37 @@
+! (register-module! ../../../../metta-moses)
+
+! (import! &self metta-moses:reduct:boolean-reduct:rte-helpers)
+! (import! &self metta-moses:utilities:general-helpers)
+! (import! &self metta-moses:reduct:boolean-reduct:cut-unnecessary-or)
+
+ ; Test : 01
+! (assertEqual (orCut ())
+    ())
+
+ ;  ; Test : 02
+! (assertEqual (orCut (OR A))
+    (A))
+
+ ;  ; Test : 03
+! (assertEqual (orCut (OR (A B C)))
+    (A B C))
+
+ ;  ; Test : 04
+! (assertEqual (orCut (OR (AND A B (NOT A))))
+    (A B (NOT A)))
+
+ ;  ; Test : 05
+! (assertEqual (orCut (OR (AND (NOT D) C)))
+    ( (NOT D) C))
+
+ ;  ; Test : 06
+! (assertEqual (orCut (OR (AND (NOT A) B C D)))
+    ( (NOT A) B C D))
+
+ ;  ; Test : 07
+! (assertEqual (orCut (OR (AND (NOT A) B C D (OR A B))))
+    ( (NOT A) B C D (OR A B)))
+
+ ;  ; Test : 08
+! (assertEqual (orCut (OR (AND (NOT A) B C (AND B C) D (OR A B))))
+    ( (NOT A) B C D (AND B C) (OR A B)))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implemented the cut unnecessary or transformation in the `cut-unnecessary-or.metta` file and added tests to test it in the tests director, `cut-unnecessary-or-test.metta`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is one of the transformations that takes place during Reduce to Elegance. It's purpose is to remove redundant OR (or nodes with a single child). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added only two files, the orCut implementation and a test file to test that function in the tests directory. No other changes were made to existing files. 
The test file for the orCut function passes all tests.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
