### PR TITLE
optimize-isConsistenetExp

### DIFF
--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -35,21 +35,30 @@
     )
 )
 
-;a function to check whether an n-ary expression is consistent or not.
+;function to check consistency of  an expression
 (= (isConsistentExp $exp)
-(let $guardSetTuple (getGuardSetExp $exp $exp ()) 
-(if (== $guardSetTuple ()) True
-        (let*
-            (
-                ($head (car-atom $guardSetTuple))
-                ($tail (cdr-atom $guardSetTuple))
-            )
-        (if (isMember (Not $head) $tail) False
-            (isConsistentExp $tail)
-        ))
-)
-)   
-)
+   (let $guardSetTuple (getGuardSetExp $exp $exp ())
+      (if (== $guardSetTuple ()) True
+          (check-negations (collapse ((superpose $guardSetTuple) (superpose $guardSetTuple))))
+             )))
+
+;function to check negation pairs to check each pair in a list of a tuple
+(= (negation-pair $a $b)
+   (or (== $a (NOT $b)) (== $b (NOT $a))))
+
+;function  to recurse through the list of the tuple to check each pair
+(= (check-negations $pairList)
+   (if (== $pairList ()) 
+       True
+       (let* (
+        ($pair (car-atom $pairList))     
+        ($first (car-atom $pair))        
+        ($second (cdr-atom $pair))  
+        ($realsecond (car-atom $second))          
+        ($pairtail (cdr-atom $pairList))) 
+          (if (negation-pair $first $realsecond)
+              False                      
+              (check-negations $pairtail))))) 
 
 ;a helper function to the zeroConstraintSubsume function
 ;a function which checks if an Expression (a representation of a node) has a child or not


### PR DESCRIPTION
## Description

I have optimized the isConsistentExp function based on the suggested implementation in the issue. The optimization leverages the non-deterministic nature of MeTTa, reducing overhead and improving performance. I defined a non-deterministic function that processes two atoms at a time. The expression in question is duplicated and passed to this function after applying superpos, ensuring that all possible combinations of the atoms in the expression are checked.

This PR closes the following issue:
- Closes #133 

## Motivation and Context
Improved performance by eliminating the need to manually iterate over atoms with car-atom and cdr-atom.
The code is more elegant and less complex due to reduced overhead and parallel execution.


## How Has This Been Tested?

I tested the changes using the existing tests in the helper-function-test.metta file to ensure that all test cases passed successfully.

## Types of changes

Optimization of the isConsistentExp function, which is used in the delete-inconsistent-handle.metta file and defined in the rte-helpers.metta file.

## Checklist:

[X] My code follows the project's code style.
[X] All new and existing tests passed.