### PR TITLE
Added New Refactored getGuardSetExpression

### DIFF
--- a/reduct/boolean-reduct/delete-inconsistent-handle.metta
+++ b/reduct/boolean-reduct/delete-inconsistent-handle.metta
@@ -1,11 +1,10 @@
-; a function which implements the Delete-Inconsistent-Handle Transformation
+ ; a function which implements the Delete-Inconsistent-Handle Transformation
 (= (deleteInconsistent $exp)
     (let*
         (
-            ($guardSet (getGuardSetExp $exp $exp ()))  
-            ($isConsistent (isConsistentExp $guardSet))  
+            ($guardSet (getGuardSetExpression $exp))
+            ($isConsistent (isConsistentExp $guardSet))
         )
-       (if $isConsistent $exp ()) 
+    (if $isConsistent $exp ())
 )
 )
-

--- a/reduct/boolean-reduct/delete-inconsistent-handle.metta
+++ b/reduct/boolean-reduct/delete-inconsistent-handle.metta
@@ -2,7 +2,7 @@
 (= (deleteInconsistent $exp)
     (let*
         (
-            ($guardSet (getGuardSetExpression $exp))
+            ($guardSet (getGuardSetExp $exp))
             ($isConsistent (isConsistentExp $guardSet))
         )
     (if $isConsistent $exp ())

--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -1,43 +1,41 @@
- ; a function to get the guardset of an n-ary expression as a tuple.
-(= (getGuardSetExp $expOriginal $expRecursive $acc)
-    (if (== (get-metatype $expOriginal) Symbol) ($expOriginal) ;if $exp is LITERAL, the guardSet is the set containing the literal itself
-        (if (== $expRecursive ()) $acc
-            (let*
-                (
-                    ($head (car-atom $expRecursive))
-                    ($headIsExpression (== (get-metatype $head) Expression))
-                    ($tail (cdr-atom $expRecursive))
-                    ($tailIsExpression (== (get-metatype $tail) Expression))
-                )
-            (if (== $head NOT)
-                (case $expOriginal
-                    (
-                        ( (NOT $b) (if (== (get-metatype $b) Symbol) $expOriginal ())) ;If the head of the expression is NOT, $b should only be a literal for it to have a guardSet of (NOT $b). If $b is an expression, the guardSet is ()
-                    )
-            )
-        (if (== $head OR) () ;an OR expression doesn't have a guardSet
-            (if (== $head AND) ; an AND expression has a guardSet which contains its literal and (NOT $literal) children
-                (getGuardSetExp $expOriginal $tail $acc)
-                (if $headIsExpression
-                    (case $head
-                        (
-                            ( (NOT $a) (getGuardSetExp $expOriginal $tail (cons-atom $head $acc)))
-                            ($else (getGuardSetExp $expOriginal $tail $acc))
-                        )
-                )
-            (getGuardSetExp $expOriginal $tail (cons-atom $head $acc))
-        )
-)
-)
-)
-)
+ ;; Partial function that is used with the getGuardSetExp
+ ;; It checks if an element in an expression can be a guardset or not
+ ;; example (NOT A) is guard set and will be returned
+ ;; example A is guard set and will be returned
+ ;; example (AND A B) is not guard set and will not be returned
+( = (isGuard $exp) (let*
+        (
+            ($type (get-metatype $exp))
+        ) (if (== $type Symbol)
+        (if (or (== AND $exp) (== OR $exp))
+            (empty)
+            $exp
+        ) (if (== (car-atom $exp) NOT)
+        $exp
+        (empty)
+    )
 )
 )
 )
 
+ ; getGuardSetExp that takes an expression and returns it's guard sets
+ ; uses the partial function isGuard to map over every element in the expression
+ ;; example (AND (NOT A) (NOT B) A) -> ( (NOT A) (NOT B) A)
+( = (getGuardSetExp $exp) (if (== $exp ()) ()
+        (if (== (get-metatype $exp) Expression) (let*
+                (
+                    ($head (car-atom $exp))
+                ) (if (== $head OR)
+                ()
+                (collapse ( isGuard (superpose $exp))))
+        )
+    (collapse ( isGuard (superpose ($exp))))
+))
+)
+
  ;a function to check whether an n-ary expression is consistent or not.
 (= (isConsistentExp $exp)
-    (let $guardSetTuple (getGuardSetExpression $exp)
+    (let $guardSetTuple (getGuardSetExp $exp)
         (if (== $guardSetTuple ()) True
             (let*
                 (
@@ -143,39 +141,4 @@
     )
 )
 )
-)
-
- ;; Partial function that is used with the getGuardSetExpression
- ;; It checks if an element in an expression can be a guardset or not
- ;; example (NOT A) is guard set and will be returned
- ;; example A is guard set and will be returned
- ;; example (AND A B) is not guard set and will not be returned
-( = (isGuard $exp) (let*
-        (
-            ($type (get-metatype $exp))
-        ) (if (== $type Symbol)
-        (if (or (== AND $exp) (== OR $exp))
-            (empty)
-            $exp
-        ) (if (== (car-atom $exp) NOT)
-        $exp
-        (empty)
-    )
-)
-)
-)
-
- ; getGuardSetExpression that takes an expression and returns it's guard sets
- ; uses the partial function isGuard to map over every element in the expression
- ;; example (AND (NOT A) (NOT B) A) -> ( (NOT A) (NOT B) A)
-( = (getGuardSetExpression $exp) (if (== $exp ()) ()
-        (if (== (get-metatype $exp) Expression) (let*
-                (
-                    ($head (car-atom $exp))
-                ) (if (== $head OR)
-                ()
-                (collapse ( isGuard (superpose $exp))))
-        )
-    (collapse ( isGuard (superpose ($exp))))
-))
 )

--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -1,25 +1,27 @@
  ;; Partial function that is used with the getGuardSetExp
  ;; It checks if an element in an expression can be a guardset or not
+ ;; returns empty if it isn't, returns the value itself if it's a guardset
  ;; example (NOT A) is guard set and will be returned
  ;; example A is guard set and will be returned
  ;; example (AND A B) is not guard set and will not be returned
-( = (isGuard $exp) (let*
-        (
-            ($type (get-metatype $exp))
-        ) (if (== $type Symbol)
-        (if (or (== AND $exp) (== OR $exp))
-            (empty)
+
+( = (ifGuard $exp) (let
+        $type
+        (get-metatype $exp)
+        (if (== $type Symbol)
+            (if (or (== AND $exp) (== OR $exp))
+                (empty)
+                $exp
+            ) (if (== (car-atom $exp) NOT)
             $exp
-        ) (if (== (car-atom $exp) NOT)
-        $exp
-        (empty)
-    )
+            (empty)
+        )
 )
 )
 )
 
  ; getGuardSetExp that takes an expression and returns it's guard sets
- ; uses the partial function isGuard to map over every element in the expression
+ ; uses the partial function ifGuard to map over every element in the expression
  ;; example (AND (NOT A) (NOT B) A) -> ( (NOT A) (NOT B) A)
 ( = (getGuardSetExp $exp) (if (== $exp ()) ()
         (if (== (get-metatype $exp) Expression) (let*
@@ -27,13 +29,13 @@
                     ($head (car-atom $exp))
                 ) (if (== $head OR)
                 ()
-                (collapse ( isGuard (superpose $exp))))
+                (collapse ( ifGuard (superpose $exp))))
         )
-    (collapse ( isGuard (superpose ($exp))))
+    (collapse ( ifGuard (superpose ($exp))))
 ))
 )
 
-;If any negation pairs are found (via areNegations), the function returns False, indicating inconsistency.
+ ;If any negation pairs are found (via areNegations), the function returns False, indicating inconsistency.
 (= (areNegations ($a $b))
     (if (== $a (NOT $b))
         True
@@ -41,24 +43,24 @@
             True
             False
         )
-    )
+)
 )
 
-;a function to check whether an n-ary expression is consistent or not.
+ ;a function to check whether an n-ary expression is consistent or not.
 (= (isConsistentExp $exp)
-    (let $guardSet (getGuardSetExp $exp $exp ())
-        (if (== $guardSet ()) 
-            True 
+    (let $guardSet (getGuardSetExp $exp)
+        (if (== $guardSet ())
+            True
             (let* (
-                ($pairs (collapse ((superpose $guardSet) (superpose $guardSet))))
-                ($result (collapse (areNegations (superpose $pairs))))
-            )
+                    ($pairs (collapse ( (superpose $guardSet) (superpose $guardSet))))
+                    ($result (collapse (areNegations (superpose $pairs))))
+                )
             (if (isMember True $result)
                 False
                 True
             ))
-        )
-    )
+)
+)
 )
 
  ;a helper function to the zeroConstraintSubsume function

--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -145,6 +145,11 @@
 )
 )
 
+ ;; Partial function that is used with the getGuardSetExpression
+ ;; It checks if an element in an expression can be a guardset or not
+ ;; example (NOT A) is guard set and will be returned
+ ;; example A is guard set and will be returned
+ ;; example (AND A B) is not guard set and will not be returned
 ( = (isGuard $exp) (let*
         (
             ($type (get-metatype $exp))
@@ -160,6 +165,9 @@
 )
 )
 
+ ; getGuardSetExpression that takes an expression and returns it's guard sets
+ ; uses the partial function isGuard to map over every element in the expression
+ ;; example (AND (NOT A) (NOT B) A) -> ( (NOT A) (NOT B) A)
 ( = (getGuardSetExpression $exp) (if (== $exp ()) ()
         (if (== (get-metatype $exp) Expression) (let*
                 (

--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -1,147 +1,173 @@
-; a function to get the guardset of an n-ary expression as a tuple. 
+ ; a function to get the guardset of an n-ary expression as a tuple.
 (= (getGuardSetExp $expOriginal $expRecursive $acc)
     (if (== (get-metatype $expOriginal) Symbol) ($expOriginal) ;if $exp is LITERAL, the guardSet is the set containing the literal itself
-    (if (== $expRecursive ()) $acc
-        (let*
-            (
-                ($head (car-atom $expRecursive))
-                ($headIsExpression (== (get-metatype $head) Expression))
-                ($tail (cdr-atom $expRecursive))
-                ($tailIsExpression (== (get-metatype $tail) Expression))
+        (if (== $expRecursive ()) $acc
+            (let*
+                (
+                    ($head (car-atom $expRecursive))
+                    ($headIsExpression (== (get-metatype $head) Expression))
+                    ($tail (cdr-atom $expRecursive))
+                    ($tailIsExpression (== (get-metatype $tail) Expression))
+                )
+            (if (== $head NOT)
+                (case $expOriginal
+                    (
+                        ( (NOT $b) (if (== (get-metatype $b) Symbol) $expOriginal ())) ;If the head of the expression is NOT, $b should only be a literal for it to have a guardSet of (NOT $b). If $b is an expression, the guardSet is ()
+                    )
             )
-            (if (== $head NOT) 
-             (case $expOriginal
-                 (
-                     ((NOT $b) (if (== (get-metatype $b) Symbol) $expOriginal ())) ;If the head of the expression is NOT, $b should only be a literal for it to have a guardSet of (NOT $b). If $b is an expression, the guardSet is ()
-                 )
-             )
-             (if (== $head OR) ()  ;an OR expression doesn't have a guardSet
-                 (if (== $head AND) ; an AND expression has a guardSet which contains its literal and (NOT $literal) children
-                     (getGuardSetExp $expOriginal $tail $acc)
-                     (if $headIsExpression
-                         (case $head
-                             (
-                                 ( (NOT $a) (getGuardSetExp $expOriginal $tail (cons-atom $head $acc)))
-                                 ($else (getGuardSetExp $expOriginal $tail $acc))
-                             )
-                         )
-                         (getGuardSetExp $expOriginal $tail (cons-atom $head $acc))
-                     )
-                 )
-             )
-            )
+        (if (== $head OR) () ;an OR expression doesn't have a guardSet
+            (if (== $head AND) ; an AND expression has a guardSet which contains its literal and (NOT $literal) children
+                (getGuardSetExp $expOriginal $tail $acc)
+                (if $headIsExpression
+                    (case $head
+                        (
+                            ( (NOT $a) (getGuardSetExp $expOriginal $tail (cons-atom $head $acc)))
+                            ($else (getGuardSetExp $expOriginal $tail $acc))
+                        )
+                )
+            (getGuardSetExp $expOriginal $tail (cons-atom $head $acc))
         )
-    ) 
-    )
+)
+)
+)
+)
+)
+)
 )
 
-;a function to check whether an n-ary expression is consistent or not.
+ ;a function to check whether an n-ary expression is consistent or not.
 (= (isConsistentExp $exp)
-(let $guardSetTuple (getGuardSetExp $exp $exp ()) 
-(if (== $guardSetTuple ()) True
-        (let*
-            (
-                ($head (car-atom $guardSetTuple))
-                ($tail (cdr-atom $guardSetTuple))
-            )
-        (if (isMember (Not $head) $tail) False
-            (isConsistentExp $tail)
-        ))
+    (let $guardSetTuple (getGuardSetExpression $exp)
+        (if (== $guardSetTuple ()) True
+            (let*
+                (
+                    ($head (car-atom $guardSetTuple))
+                    ($tail (cdr-atom $guardSetTuple))
+                )
+            (if (isMember (Not $head) $tail) False
+                (isConsistentExp $tail)
+            ))
 )
-)   
+)
 )
 
-;a helper function to the zeroConstraintSubsume function
-;a function which checks if an Expression (a representation of a node) has a child or not
+ ;a helper function to the zeroConstraintSubsume function
+ ;a function which checks if an Expression (a representation of a node) has a child or not
 (= (nodeHasChildExp $node)
-(let*
-(
-    ($head (car-atom $node))
-    ($tail (cdr-atom $node))
-    ($nodeType (get-metatype $node))
-)
-(if (== $nodeType Symbol) 
- False 
- (if (== $tail ()) 
-     False 
-     True
- )
+    (let*
+        (
+            ($head (car-atom $node))
+            ($tail (cdr-atom $node))
+            ($nodeType (get-metatype $node))
+        )
+    (if (== $nodeType Symbol)
+        False
+        (if (== $tail ())
+            False
+            True
+        )
 )
 )
 )
 
-;a function that will return Gardset(literals for OR) and the children as a tuple ((Gset), (Children))
+ ;a function that will return Gardset(literals for OR) and the children as a tuple ((Gset), (Children))
 (= (GsetandChildren $expr $literals $nonLiterals)
     (if (== $expr ())
         ($literals $nonLiterals)
-        (let* 
-            (   
+        (let*
+            (
                 ($head (car-atom $expr))
                 ($tail (cdr-atom $expr))
                 ($isLiteral (or (== (get-metatype $head) Symbol) (unify $head (NOT $_) True False)))
             )
-            (if (or (== $head AND) (== $head OR)) 
-                (GsetandChildren $tail $literals $nonLiterals)
+        (if (or (== $head AND) (== $head OR))
+            (GsetandChildren $tail $literals $nonLiterals)
 
-                (if $isLiteral 
-                    (GsetandChildren $tail (concatTuple $literals ($head)) $nonLiterals)
-                    (GsetandChildren $tail $literals (concatTuple $nonLiterals ($head)))        
-                )
+            (if $isLiteral
+                (GsetandChildren $tail (concatTuple $literals ($head)) $nonLiterals)
+                (GsetandChildren $tail $literals (concatTuple $nonLiterals ($head)))
             )
-        )
     )
+)
+)
 )
 
 (= (getGsetAndChildren $expr) (GsetandChildren $expr () ()))
 
-; Function to find common literals between a tuple and a nested tuple
+ ; Function to find common literals between a tuple and a nested tuple
 (= (findCommonLiterals $tuple $nestedTuple)
     (if (or (== $nestedTuple ()) (== $tuple ()))
         ()
-        (let* 
+        (let*
             (
                 ($first (car-atom $nestedTuple))
                 ($tail (cdr-atom $nestedTuple))
                 ($common (collapse (intersection (superpose $tuple) (superpose $first))))
             )
-            (if (== $tail ())
-                $common
-                (findCommonLiterals $common $tail)
-            )
+        (if (== $tail ())
+            $common
+            (findCommonLiterals $common $tail)
         )
-    )
+)
+)
 )
 
-; Function to find common literals in a nested tuple
+ ; Function to find common literals in a nested tuple
 (= (findCommon $nestedTuple)
     (if (or (== $nestedTuple ()) (== (cdr-atom $nestedTuple) ()))
         ()
         (let* (
-            ($first (car-atom $nestedTuple))
-            ($tail (cdr-atom $nestedTuple))
-        )
+                ($first (car-atom $nestedTuple))
+                ($tail (cdr-atom $nestedTuple))
+            )
         (findCommonLiterals $first $tail)
-        )
     )
 )
-;function to find returin the Gardset of an expression
+)
+ ;function to find returin the Gardset of an expression
 (= (getGuardSet $expr $acc)
     (if (== $expr ())
         $acc
-        (let* 
+        (let*
             (
                 ($head (car-atom $expr))
                 ($tail (cdr-atom $expr))
                 ($isLiteral (or (== (get-metatype $head) Symbol) (unify $head (NOT $_) True False)))
             )
-            (if (or (== $head AND) (== $head OR)) 
+        (if (or (== $head AND) (== $head OR))
+            (getGuardSet $tail $acc)
+            (if $isLiteral
+                (getGuardSet $tail (concatTuple $acc ($head)))
                 (getGuardSet $tail $acc)
-                (if $isLiteral 
-                    (getGuardSet $tail (concatTuple $acc ($head)))
-                    (getGuardSet $tail $acc)
-                )
             )
-        )
     )
 )
+)
+)
 
+( = (isGuard $exp) (let*
+        (
+            ($type (get-metatype $exp))
+        ) (if (== $type Symbol)
+        (if (or (== AND $exp) (== OR $exp))
+            (empty)
+            $exp
+        ) (if (== (car-atom $exp) NOT)
+        $exp
+        (empty)
+    )
+)
+)
+)
+
+( = (getGuardSetExpression $exp) (if (== $exp ()) ()
+        (if (== (get-metatype $exp) Expression) (let*
+                (
+                    ($head (car-atom $exp))
+                ) (if (== $head OR)
+                ()
+                (collapse ( isGuard (superpose $exp))))
+        )
+    (collapse ( isGuard (superpose ($exp))))
+))
+)

--- a/reduct/boolean-reduct/tests/helper-functions-test.metta
+++ b/reduct/boolean-reduct/tests/helper-functions-test.metta
@@ -3,46 +3,66 @@
 ! (import! &self metta-moses:utilities:general-helpers)
 ! (import! &self metta-moses:reduct:boolean-reduct:rte-helpers)
 
-;; Test for getGuardSetExp
+ ;; Test for getGuardSetExp
 
-;; Test 01 - getGuardSet of an empty set
-! (assertEqualToResult (getGuardSetExp () () ()) (()))
+ ;; Test 01 - getGuardSet of an empty set
+! (assertEqualToResult (getGuardSetExp () () ()) ( ()))
 
-;; Test 02 - getGuardSet of a literal
-! (assertEqualToResult (getGuardSetExp A A ()) ((A)))
-! (assertEqualToResult (getGuardSetExp (A) (A) ()) ((A)))
+ ;; Test 02 - getGuardSet of a literal
+! (assertEqualToResult (getGuardSetExp A A ()) ( (A)))
+! (assertEqualToResult (getGuardSetExp (A) (A) ()) ( (A)))
 
-;; Test 02 - getGuardSet of OR and NOT expressions
-! (assertEqualToResult (getGuardSetExp (OR) (OR) ()) (()))
-! (assertEqualToResult (getGuardSetExp (OR A B (NOT A)) (OR A B (NOT A)) ()) (()))
-! (assertEqualToResult (getGuardSetExp (OR (AND A B) (AND A B) (NOT A)) (OR (AND A B) (AND A B) (NOT A)) ()) (()))
+ ;; Test 02 - getGuardSet of OR and NOT expressions
+! (assertEqualToResult (getGuardSetExp (OR) (OR) ()) ( ()))
+! (assertEqualToResult (getGuardSetExp (OR A B (NOT A)) (OR A B (NOT A)) ()) ( ()))
+! (assertEqualToResult (getGuardSetExp (OR (AND A B) (AND A B) (NOT A)) (OR (AND A B) (AND A B) (NOT A)) ()) ( ()))
 
-;; Test 03 - getGuardSet of AND expressions
-! (assertEqualToResult (getGuardSetExp (AND) (AND) ()) (()))
-! (assertEqualToResult (getGuardSetExp (AND A) (AND A) ()) ((A)))
-! (assertEqualToResult (getGuardSetExp (AND (NOT A) (NOT B) A) (AND (NOT A) (NOT B) A) ()) ((A (NOT B) (NOT A))))
-! (assertEqualToResult (getGuardSetExp (AND A (AND A B) (OR A B) (NOT B)) (AND A (AND A B) (OR A B) (NOT B)) ()) (((NOT B) A)))
-! (assertEqualToResult (getGuardSetExp (AND (AND A B) A) (AND (AND A B) A) ()) ((A)))
-! (assertEqualToResult (getGuardSetExp (AND A B (NOT B)) (AND A B (NOT B)) ()) (((NOT B) B A)))
-! (assertEqualToResult (getGuardSetExp (AND A (NOT A) (NOT B)) (AND A (NOT A) (NOT B)) ()) (((NOT B) (NOT A) A)))
-! (assertEqualToResult (getGuardSetExp (AND (NOT A) A B) (AND (NOT A) A B) ()) ((B A (NOT A))))
+ ;; Test 03 - getGuardSet of AND expressions
+! (assertEqualToResult (getGuardSetExp (AND) (AND) ()) ( ()))
+! (assertEqualToResult (getGuardSetExp (AND A) (AND A) ()) ( (A)))
+! (assertEqualToResult (getGuardSetExp (AND (NOT A) (NOT B) A) (AND (NOT A) (NOT B) A) ()) ( (A (NOT B) (NOT A))))
+! (assertEqualToResult (getGuardSetExp (AND A (AND A B) (OR A B) (NOT B)) (AND A (AND A B) (OR A B) (NOT B)) ()) ( ( (NOT B) A)))
+! (assertEqualToResult (getGuardSetExp (AND (AND A B) A) (AND (AND A B) A) ()) ( (A)))
+! (assertEqualToResult (getGuardSetExp (AND A B (NOT B)) (AND A B (NOT B)) ()) ( ( (NOT B) B A)))
+! (assertEqualToResult (getGuardSetExp (AND A (NOT A) (NOT B)) (AND A (NOT A) (NOT B)) ()) ( ( (NOT B) (NOT A) A)))
+! (assertEqualToResult (getGuardSetExp (AND (NOT A) A B) (AND (NOT A) A B) ()) ( (B A (NOT A))))
 
-;; Test for isConsistentExp
- ! (assertEqualToResult (isConsistentExp ()) (True))
- ! (assertEqualToResult (isConsistentExp A) (True))
- ! (assertEqualToResult (isConsistentExp (A)) (True))
- ! (assertEqualToResult (isConsistentExp (AND)) (True))
- ! (assertEqualToResult (isConsistentExp (AND (OR A B) (AND A B) A B)) (True))
- ! (assertEqualToResult (isConsistentExp (AND (NOT A) (NOT B) A)) (False))
- ! (assertEqualToResult (isConsistentExp (AND A B (NOT B))) (False))
- ! (assertEqualToResult (isConsistentExp (OR A B (NOT A))) (True))
- ! (assertEqualToResult (isConsistentExp (OR (AND A B) (AND A B) (NOT A))) (True))
- ! (assertEqualToResult (isConsistentExp (AND A (NOT A) (NOT B))) (False))
+ ;; Test for isConsistentExp
+! (assertEqualToResult (isConsistentExp ()) (True))
+! (assertEqualToResult (isConsistentExp A) (True))
+! (assertEqualToResult (isConsistentExp (A)) (True))
+! (assertEqualToResult (isConsistentExp (AND)) (True))
+! (assertEqualToResult (isConsistentExp (AND (OR A B) (AND A B) A B)) (True))
+! (assertEqualToResult (isConsistentExp (AND (NOT A) (NOT B) A)) (False))
+! (assertEqualToResult (isConsistentExp (AND A B (NOT B))) (False))
+! (assertEqualToResult (isConsistentExp (OR A B (NOT A))) (True))
+! (assertEqualToResult (isConsistentExp (OR (AND A B) (AND A B) (NOT A))) (True))
+! (assertEqualToResult (isConsistentExp (AND A (NOT A) (NOT B))) (False))
 
- ! (assertEqualToResult (nodeHasChildExp (AND A B)) (True))
- ! (assertEqualToResult (nodeHasChildExp (AND A B C)) (True))
- ! (assertEqualToResult (nodeHasChildExp (OR A B C)) (True))
- ! (assertEqualToResult (nodeHasChildExp (A)) (False))
- ! (assertEqualToResult (nodeHasChildExp A) (False))
- ! (assertEqualToResult (nodeHasChildExp (AND)) (False))
- ! (assertEqualToResult (nodeHasChildExp AND) (False))
+! (assertEqualToResult (nodeHasChildExp (AND A B)) (True))
+! (assertEqualToResult (nodeHasChildExp (AND A B C)) (True))
+! (assertEqualToResult (nodeHasChildExp (OR A B C)) (True))
+! (assertEqualToResult (nodeHasChildExp (A)) (False))
+! (assertEqualToResult (nodeHasChildExp A) (False))
+! (assertEqualToResult (nodeHasChildExp (AND)) (False))
+! (assertEqualToResult (nodeHasChildExp AND) (False))
+
+ ;; Tests for new getGuardSetExpression
+ ;  ;; Test 02 - getGuardSet of a literal
+! (assertEqualToResult (getGuardSetExpression A) ( (A)))
+! (assertEqualToResult (getGuardSetExpression (A)) ( (A)))
+
+ ;  ;  ;; Test 02 - getGuardSet of OR and NOT expressions
+! (assertEqualToResult (getGuardSetExpression (OR)) ( ()))
+! (assertEqualToResult (getGuardSetExpression (OR A B (NOT A))) ( ()))
+! (assertEqualToResult (getGuardSetExpression (OR (AND A B) (AND A B) (NOT A))) ( ()))
+
+ ;  ;  ;; Test 03 - getGuardSet of AND expressions
+! (assertEqualToResult (getGuardSetExpression (AND)) ( ()))
+! (assertEqualToResult (getGuardSetExpression (AND A)) ( (A)))
+! (assertEqualToResult (getGuardSetExpression (AND (NOT A) (NOT B) A)) ( ( (NOT A) (NOT B) A)))
+! (assertEqualToResult (getGuardSetExpression (AND A (AND A B) (OR A B) (NOT B))) ( ( A (NOT B))))
+! (assertEqualToResult (getGuardSetExpression (AND (AND A B) A) ) ( (A)))
+! (assertEqualToResult (getGuardSetExpression (AND A B (NOT B)) ) ( (  A B (NOT B) )))
+! (assertEqualToResult (getGuardSetExpression (AND A (NOT A) (NOT B))) ( ( A (NOT A) (NOT B) )))
+! (assertEqualToResult (getGuardSetExpression (AND (NOT A) A B)) ( ( (NOT A) A B)))

--- a/reduct/boolean-reduct/tests/helper-functions-test.metta
+++ b/reduct/boolean-reduct/tests/helper-functions-test.metta
@@ -5,27 +5,25 @@
 
  ;; Test for getGuardSetExp
 
- ;; Test 01 - getGuardSet of an empty set
-! (assertEqualToResult (getGuardSetExp () () ()) ( ()))
+ ;; Tests for new getGuardSetExp
+ ;  ;; Test 01 - getGuardSet of a literal
+! (assertEqualToResult (getGuardSetExp A) ( (A)))
+! (assertEqualToResult (getGuardSetExp (A)) ( (A)))
 
- ;; Test 02 - getGuardSet of a literal
-! (assertEqualToResult (getGuardSetExp A A ()) ( (A)))
-! (assertEqualToResult (getGuardSetExp (A) (A) ()) ( (A)))
+ ;  ;  ;; Test 02 - getGuardSet of OR and NOT expressions
+! (assertEqualToResult (getGuardSetExp (OR)) ( ()))
+! (assertEqualToResult (getGuardSetExp (OR A B (NOT A))) ( ()))
+! (assertEqualToResult (getGuardSetExp (OR (AND A B) (AND A B) (NOT A))) ( ()))
 
- ;; Test 02 - getGuardSet of OR and NOT expressions
-! (assertEqualToResult (getGuardSetExp (OR) (OR) ()) ( ()))
-! (assertEqualToResult (getGuardSetExp (OR A B (NOT A)) (OR A B (NOT A)) ()) ( ()))
-! (assertEqualToResult (getGuardSetExp (OR (AND A B) (AND A B) (NOT A)) (OR (AND A B) (AND A B) (NOT A)) ()) ( ()))
-
- ;; Test 03 - getGuardSet of AND expressions
-! (assertEqualToResult (getGuardSetExp (AND) (AND) ()) ( ()))
-! (assertEqualToResult (getGuardSetExp (AND A) (AND A) ()) ( (A)))
-! (assertEqualToResult (getGuardSetExp (AND (NOT A) (NOT B) A) (AND (NOT A) (NOT B) A) ()) ( (A (NOT B) (NOT A))))
-! (assertEqualToResult (getGuardSetExp (AND A (AND A B) (OR A B) (NOT B)) (AND A (AND A B) (OR A B) (NOT B)) ()) ( ( (NOT B) A)))
-! (assertEqualToResult (getGuardSetExp (AND (AND A B) A) (AND (AND A B) A) ()) ( (A)))
-! (assertEqualToResult (getGuardSetExp (AND A B (NOT B)) (AND A B (NOT B)) ()) ( ( (NOT B) B A)))
-! (assertEqualToResult (getGuardSetExp (AND A (NOT A) (NOT B)) (AND A (NOT A) (NOT B)) ()) ( ( (NOT B) (NOT A) A)))
-! (assertEqualToResult (getGuardSetExp (AND (NOT A) A B) (AND (NOT A) A B) ()) ( (B A (NOT A))))
+ ;  ;  ;; Test 03 - getGuardSet of AND expressions
+! (assertEqualToResult (getGuardSetExp (AND)) ( ()))
+! (assertEqualToResult (getGuardSetExp (AND A)) ( (A)))
+! (assertEqualToResult (getGuardSetExp (AND (NOT A) (NOT B) A)) ( ( (NOT A) (NOT B) A)))
+! (assertEqualToResult (getGuardSetExp (AND A (AND A B) (OR A B) (NOT B))) ( ( A (NOT B))))
+! (assertEqualToResult (getGuardSetExp (AND (AND A B) A) ) ( (A)))
+! (assertEqualToResult (getGuardSetExp (AND A B (NOT B)) ) ( (  A B (NOT B) )))
+! (assertEqualToResult (getGuardSetExp (AND A (NOT A) (NOT B))) ( ( A (NOT A) (NOT B) )))
+! (assertEqualToResult (getGuardSetExp (AND (NOT A) A B)) ( ( (NOT A) A B)))
 
  ;; Test for isConsistentExp
 ! (assertEqualToResult (isConsistentExp ()) (True))
@@ -46,23 +44,3 @@
 ! (assertEqualToResult (nodeHasChildExp A) (False))
 ! (assertEqualToResult (nodeHasChildExp (AND)) (False))
 ! (assertEqualToResult (nodeHasChildExp AND) (False))
-
- ;; Tests for new getGuardSetExpression
- ;  ;; Test 02 - getGuardSet of a literal
-! (assertEqualToResult (getGuardSetExpression A) ( (A)))
-! (assertEqualToResult (getGuardSetExpression (A)) ( (A)))
-
- ;  ;  ;; Test 02 - getGuardSet of OR and NOT expressions
-! (assertEqualToResult (getGuardSetExpression (OR)) ( ()))
-! (assertEqualToResult (getGuardSetExpression (OR A B (NOT A))) ( ()))
-! (assertEqualToResult (getGuardSetExpression (OR (AND A B) (AND A B) (NOT A))) ( ()))
-
- ;  ;  ;; Test 03 - getGuardSet of AND expressions
-! (assertEqualToResult (getGuardSetExpression (AND)) ( ()))
-! (assertEqualToResult (getGuardSetExpression (AND A)) ( (A)))
-! (assertEqualToResult (getGuardSetExpression (AND (NOT A) (NOT B) A)) ( ( (NOT A) (NOT B) A)))
-! (assertEqualToResult (getGuardSetExpression (AND A (AND A B) (OR A B) (NOT B))) ( ( A (NOT B))))
-! (assertEqualToResult (getGuardSetExpression (AND (AND A B) A) ) ( (A)))
-! (assertEqualToResult (getGuardSetExpression (AND A B (NOT B)) ) ( (  A B (NOT B) )))
-! (assertEqualToResult (getGuardSetExpression (AND A (NOT A) (NOT B))) ( ( A (NOT A) (NOT B) )))
-! (assertEqualToResult (getGuardSetExpression (AND (NOT A) A B)) ( ( (NOT A) A B)))

--- a/reduct/boolean-reduct/zero-constraint-subsumption.metta
+++ b/reduct/boolean-reduct/zero-constraint-subsumption.metta
@@ -1,24 +1,24 @@
-;a function which implements the 0-Constraint-Subsumption Transformation
+ ;a function which implements the 0-Constraint-Subsumption Transformation
 (= (zeroConstraintSubsume $expOriginal $expRecursive)
-(if (== $expRecursive ()) $expOriginal 
-(let*
-(
-    ($head (car-atom $expRecursive))
-    ($tail (cdr-atom $expRecursive))
-    ($headType (get-metatype $head))
-    ($headHasNoChild (not (nodeHasChildExp $head)))
-)
-(case $head
-(
-   (AND $expOriginal)
-   (NOT $expOriginal)
-   (OR (zeroConstraintSubsume $expOriginal $tail))  ;the POA for this transformation is any OR node
-   ($else (if (and (== (getGuardSetExp $head $head ()) ()) $headHasNoChild)
-              () ;if any child of the POA has an empty guardSet and no child, it is removed. if not, it's kept.
-              (zeroConstraintSubsume $expOriginal $tail)
-          ) 
+    (if (== $expRecursive ()) $expOriginal
+        (let*
+            (
+                ($head (car-atom $expRecursive))
+                ($tail (cdr-atom $expRecursive))
+                ($headType (get-metatype $head))
+                ($headHasNoChild (not (nodeHasChildExp $head)))
+            )
+        (case $head
+            (
+                (AND $expOriginal)
+                (NOT $expOriginal)
+                (OR (zeroConstraintSubsume $expOriginal $tail)) ;the POA for this transformation is any OR node
+                ($else (if (and (== (getGuardSetExp $head) ()) $headHasNoChild)
+                        () ;if any child of the POA has an empty guardSet and no child, it is removed. if not, it's kept.
+                        (zeroConstraintSubsume $expOriginal $tail)
+                    )
+            )
     )
-)  
 )
 )
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I have added a new refactored version of the `getGuardSetExp` named `getGuardSetExpression` that uses `superpose` to increase performance and run in parallel. The new function is 
I haven't removed the old function since it is used in the module `zero-constraint-subsumption.metta`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- reduces the overhead of using car-atom and cdr-atom for iteration over the atom one at a time.
- have better performance if done in parallel.
- It closes issue #132
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- all previous test scripts pass
- additional tests have been added to cover the new function added
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
