### PR TITLE
Modify getGuardSetExp

### DIFF
--- a/reduct/boolean-reduct/delete-inconsistent-handle.metta
+++ b/reduct/boolean-reduct/delete-inconsistent-handle.metta
@@ -2,7 +2,7 @@
 (= (deleteInconsistent $exp)
     (let*
         (
-            ($guardSet (getGuardSetExp $exp $exp ()))  
+            ($guardSet (getGuardSetExp $exp))  
             ($isConsistent (isConsistentExp $guardSet))  
         )
        (if $isConsistent $exp ()) 

--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -6,11 +6,13 @@
             ()
             (collapse (let* (($tail (cdr-atom $expr))
                             ($x (superpose $tail)))
-                                (if (== (get-metatype $x) Symbol)
-                                    $x 
-                                    (if (== (car-atom $x) NOT)
-                                        $x
-                                        (empty)))
+                            (if (== (get-metatype $x) Symbol)
+                                $x 
+                                (if (== (car-atom $x) NOT)
+                                    $x
+                                    (empty)
+                                )
+                            )
                     ) 
             )  
         )

--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -19,7 +19,7 @@
 
 ;a function to check whether an n-ary expression is consistent or not.
 (= (isConsistentExp $exp)
-(let $guardSetTuple (getGuardSetExp $exp $exp ()) 
+(let $guardSetTuple (getGuardSetExp $exp) 
 (if (== $guardSetTuple ()) True
         (let*
             (

--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -1,37 +1,19 @@
 ; a function to get the guardset of an n-ary expression as a tuple. 
-(= (getGuardSetExp $expOriginal $expRecursive $acc)
-    (if (== (get-metatype $expOriginal) Symbol) ($expOriginal) ;if $exp is LITERAL, the guardSet is the set containing the literal itself
-    (if (== $expRecursive ()) $acc
-        (let*
-            (
-                ($head (car-atom $expRecursive))
-                ($headIsExpression (== (get-metatype $head) Expression))
-                ($tail (cdr-atom $expRecursive))
-                ($tailIsExpression (== (get-metatype $tail) Expression))
-            )
-            (if (== $head NOT) 
-             (case $expOriginal
-                 (
-                     ((NOT $b) (if (== (get-metatype $b) Symbol) $expOriginal ())) ;If the head of the expression is NOT, $b should only be a literal for it to have a guardSet of (NOT $b). If $b is an expression, the guardSet is ()
-                 )
-             )
-             (if (== $head OR) ()  ;an OR expression doesn't have a guardSet
-                 (if (== $head AND) ; an AND expression has a guardSet which contains its literal and (NOT $literal) children
-                     (getGuardSetExp $expOriginal $tail $acc)
-                     (if $headIsExpression
-                         (case $head
-                             (
-                                 ( (NOT $a) (getGuardSetExp $expOriginal $tail (cons-atom $head $acc)))
-                                 ($else (getGuardSetExp $expOriginal $tail $acc))
-                             )
-                         )
-                         (getGuardSetExp $expOriginal $tail (cons-atom $head $acc))
-                     )
-                 )
-             )
-            )
+(= (getGuardSetExp $expr)
+    (if (== $expr ())
+        ()
+        (if (== (car-atom $expr) OR)
+            ()
+            (collapse (let* (($tail (cdr-atom $expr))
+                            ($x (superpose $tail)))
+                                (if (== (get-metatype $x) Symbol)
+                                    $x 
+                                    (if (== (car-atom $x) NOT)
+                                        $x
+                                        (empty)))
+                    ) 
+            )  
         )
-    ) 
     )
 )
 

--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -1,4 +1,4 @@
-; a function to get the guardset of an n-ary expression as a tuple. 
+; a function to get the guardset of an n-ary expression as a tuple.
 (= (getGuardSetExp $expr)
     (if (== $expr ())
         ()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refactors the `getGuardSetExp` function, defined in `rte-helpers.metta`, to optimize its performance by eliminating the need for iterative checking of each atom. The previous implementation used `car-atom` and `cdr-atom` to iterate over expressions one at a time. The new version implements a non-deterministic approach, leveraging parallel processing through `superpose` to evaluate guard sets more efficiently.  

## Motivation and Context
This change is required to improve the performance of the `getGuardSetExp` function. The previous iteration method introduced unnecessary overhead, making the function less efficient when evaluating large expressions. By refactoring the function, we enhance its performance and reduce latency, ultimately leading to faster evaluations of guard sets. It closes issue #132 

## How Has This Been Tested?
The refactored function has been tested using existing unit tests to ensure that its output matches expected results. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
