### PR TITLE
Optimized the isConsistentExp to use a non deterministic approach

### DIFF
--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -36,10 +36,15 @@
 )
 
 ;If any negation pairs are found (via areNegations), the function returns False, indicating inconsistency.
-
 (= (areNegations ($a $b))
-    (or (unify $a (NOT $b) True False)
-        (unify $b (NOT $a) True False)))
+    (if (== $a (NOT $b))
+        True
+        (if (== $b (NOT $a))
+            True
+            False
+        )
+    )
+)
 
 ;a function to check whether an n-ary expression is consistent or not.
 (= (isConsistentExp $exp)

--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -36,19 +36,26 @@
 )
 
 ;a function to check whether an n-ary expression is consistent or not.
+;If any negation pairs are found (via areNegations), the function returns False, indicating inconsistency.
+
+(= (areNegations ($a $b))
+    (or (unify $a (NOT $b) True False)
+        (unify $b (NOT $a) True False)))
+
 (= (isConsistentExp $exp)
-(let $guardSetTuple (getGuardSetExp $exp $exp ()) 
-(if (== $guardSetTuple ()) True
-        (let*
-            (
-                ($head (car-atom $guardSetTuple))
-                ($tail (cdr-atom $guardSetTuple))
+    (let $guardSet (getGuardSetExp $exp $exp ())
+        (if (== $guardSet ()) 
+            True 
+            (let* (
+                ($pairs (collapse ((superpose $guardSet) (superpose $guardSet))))
+                ($result (collapse (areNegations (superpose $pairs))))
             )
-        (if (isMember (Not $head) $tail) False
-            (isConsistentExp $tail)
-        ))
-)
-)   
+            (if (isMember True $result)
+                False
+                True
+            ))
+        )
+    )
 )
 
 ;a helper function to the zeroConstraintSubsume function

--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -35,13 +35,13 @@
     )
 )
 
-;a function to check whether an n-ary expression is consistent or not.
 ;If any negation pairs are found (via areNegations), the function returns False, indicating inconsistency.
 
 (= (areNegations ($a $b))
     (or (unify $a (NOT $b) True False)
         (unify $b (NOT $a) True False)))
 
+;a function to check whether an n-ary expression is consistent or not.
 (= (isConsistentExp $exp)
     (let $guardSet (getGuardSetExp $exp $exp ())
         (if (== $guardSet ()) 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I added the `areNegations` function to check for negation pairs in expressions and updated the `isConsistentExp` function. The changes include leveraging non-determinism by replacing `car-atom` and `cdr-atom` with `superpose` and `collapse` for generating and checking expression pairs, ensuring more efficient consistency checks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change improves the consistency check for logical expressions by adding non-deterministic evaluation. The previous implementation using car-atom and cdr-atom was limited in handling multiple expressions. By incorporating superpose and collapse, the update ensures more flexible pair generation and negation checking, resulting in a more robust consistency check
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #133

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested it using the test cases that were in the repository
<!--- Include details of your testing environment, and the tests you ran to -->
I used the assertequal tests
<!--- see how your change affects other areas of the code, etc. -->
The isConsistentExp is used in other functions to test expressions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
