### PR TITLE
one-constraint-complement-subtraction transformation 

### DIFF
--- a/reduct/boolean-reduct/one-constraint-compIement-subtraction.metta
+++ b/reduct/boolean-reduct/one-constraint-compIement-subtraction.metta
@@ -1,0 +1,54 @@
+;; Name:                        oneCcSub
+;; Parameters:              
+;;                              1:- $parent, a boolean expression possibly containing a non-root AND node, 
+;;                              the POA and a commanding terminal AND node, COM.
+;;                              2:- $poa, the point of application from whose literal is to be subtracted.
+;;                              3:- $com, the guard set of the commanding AND node possibly containing
+;;                              a negated form of a member of the guard set of the POA.
+;; Goal:                        To remove a constraint which is not needed because it is commanded by its negated form.
+;; Point of application(POA):   Any non-root AND node.
+;; Preconditions:               The POA’s guard set contains constraint X and the POA is commanded
+;;                              by a terminal AND node COM whose guard set consists of the constraint 
+;;                              which is the opposite of X.
+;;
+;; Action:                      Subtract the constraint X from the guard set of the POA.
+;; Example Function call        $parent <- (OR (AND D) (AND B C)), $poa <- (AND B C), $com <- ((NOT B) C)                    
+;;                              oneCcSub ((OR (AND D) (AND B C)) (AND B C) ((NOT B) C)) -> (OR (AND D) (AND C))
+
+(= (oneCcSub $parent $poa $com)
+    (let* 
+        (
+            ($poaGuardSet (getGuardSet $poa))
+            ($invertedCom (invertLiterals $com))
+            ($commonElements (collapse (intersection (superpose $poaGuardSet) (superpose $invertedCom))))
+        )
+         (collapse (let $el (superpose $parent)
+            (if (expressionEquality $el $poa)
+                (collapse (subtraction (superpose $poa) (superpose $commonElements)))
+                $el)))))
+                
+;; Name:                        expressionEquality
+;; Description:                 A helper function to evaluate equality of two expressions ignoring ordering of litral children.
+;;                              The grounded equality operator, ==, will return `False` when comparing (AND A B) and (AND B A)
+;;                              expressionEquality returns `True`.
+;;                              Used when looking for the POA in the parent's list of children.
+
+(= (expressionEquality $a $b)
+    (let $diff (collapse (subtraction (superpose $a) (superpose $b)))
+        (if (== $diff ())
+            True
+            False
+        )))
+
+;; Name:                        invertLiterals
+;; Description:                 A helper function that negates all literals in a literal only expression.
+;;                              Used when finding a negated literal of the POA in the guardset of the commanding AND node.
+;; Example:                     invertLiterals (A B) -> ((NOT A) (NOT B))
+;;                              invertLiterals (A (NOT B)) -> ((NOT A) B)
+
+(= (invertLiterals $guardSet)
+    (collapse (let $literal (superpose $guardSet)
+            (unify $literal (NOT $x)
+                $x
+                (NOT $literal)
+            ))))

--- a/reduct/boolean-reduct/tests/one-constraint-compIement-subtraction-test.metta
+++ b/reduct/boolean-reduct/tests/one-constraint-compIement-subtraction-test.metta
@@ -1,0 +1,48 @@
+! (register-module! ../../../../metta-moses) 
+
+! (import! &self metta-moses:reduct:boolean-reduct:rte-helpers)
+! (import! &self metta-moses:utilities:general-helpers)
+! (import! &self metta-moses:reduct:boolean-reduct:one-constraint-complement-subtraction)
+
+;; Test 01
+!(assertEqual 
+    (oneCcSub (OR (AND D) (AND B C)) (AND B C) ((NOT B) C))
+    (OR (AND D) (AND C))
+)
+
+;; Test 02
+!(assertEqual 
+    (oneCcSub (AND (AND B A) (AND B (NOT C))) (AND B A) ((NOT B) C))
+    (AND (AND A) (AND B (NOT C)))
+)
+
+;; Test 03
+!(assertEqual 
+    (oneCcSub (AND A (AND B A) (NOT D) (AND B (NOT C))) (AND B A) ((NOT B) C))
+    (AND A (AND A) (NOT D) (AND B (NOT C)))
+)
+
+;; Test 04
+! (assertEqual 
+    (oneCcSub (AND (AND D C) (NOT B) A (AND B C)) (AND B C) ((NOT B) C))
+    (AND (AND D C) (NOT B) A (AND C))
+)
+;; Test 05
+! (assertEqual 
+    (oneCcSub (OR (AND (NOT A) C) (OR A B (AND B C))) (AND (NOT A) C) (A B C))
+    (OR (AND C) (OR A B (AND B C)))
+)
+
+;; No reduction
+
+;; Test 06
+! (assertEqual 
+    (oneCcSub (AND (AND D C) (NOT B) A (AND B C)) (AND A C) ((NOT B) C))
+    (AND (AND D C) (NOT B) A (AND B C))
+)
+
+;; Test 07
+! (assertEqual 
+    (oneCcSub (OR (AND (NOT A) C) (AND A B (AND B C))) (AND (NOT A) C) ((NOT A) B C))
+    (OR (AND (NOT A) C) (AND A B (AND B C)))
+)


### PR DESCRIPTION
Add the main function, oneCcSub, for one-constraint-complement-subtraction transformation and test cases.

## Boolean Expression Reduction
Removes a literal from a non-root AND node if its negated form is in the guard set of a commanding AND node.

## How Has This Been Tested?
The test cases were run locally using the *metta-moses/scripts/py-test.py*.

## Types of changes
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
