### PR TITLE
Bug fix on scoring for single variables.

### DIFF
--- a/scoring/fitness.metta
+++ b/scoring/fitness.metta
@@ -24,16 +24,18 @@
  ;; If a variable is not found, it is replaced with undefined.
 (= (replaceWithTruth $expr $space $spaceContent)
     (if (== (get-metatype $expr) Expression) 
-        (let* (
-            ($op (car-atom $expr))
-            ($tuple (cdr-atom $expr)) 
-            ($substitutedArgs (collapse (replaceWithTruth (superpose $tuple) $space $spaceContent)) )
-
-            ($tupleWithOp (cons-atom $op $substitutedArgs))
+        (if (and (not (== (car-atom $expr) ())) (== (cdr-atom $expr) ())) ;; Special case: (A) → Should replace as a symbol
+            (collapse (replaceWithTruth (superpose $expr) $space $spaceContent))
+            (let* (
+                ($op (car-atom $expr))
+                ($tuple (cdr-atom $expr)) 
+                ($substitutedArgs (collapse (replaceWithTruth (superpose $tuple) $space $spaceContent)) )
+                ($tupleWithOp (cons-atom $op $substitutedArgs))
+            )
+                $tupleWithOp
+            )
         )
-            $tupleWithOp
-        )
-         (unify $space ($expr $value) $value undefined) 
+        ((unify $space ($expr $value) $value undefined)) ;; If not an Expression, replace normally
     )
 )
 
@@ -49,12 +51,15 @@
 (= (evaluate $expr)
     (if (== (get-metatype $expr) Grounded) ;; T / F
         $expr
-        (case (car-atom $expr) 
-            (
-                (AND (evaluateAnd (cdr-atom $expr)))
-                (OR (evaluateOr (cdr-atom $expr)))
-                (NOT (not (evaluate (cdr-atom $expr))))
-                ($_ ERROR)
+        (if (and (not (== (car-atom $expr) ())) (== (cdr-atom $expr) ()))  ;;  Handle (True) or (False)
+            (evaluate (car-atom $expr))  ;; Extract the actual boolean value
+            (case (car-atom $expr) 
+                (
+                    (AND (evaluateAnd (cdr-atom $expr)))
+                    (OR (evaluateOr (cdr-atom $expr)))
+                    (NOT (not (evaluate (cdr-atom $expr)))) 
+                    ($_ ERROR)
+                )
             )
         )
     )
@@ -162,7 +167,7 @@
 ;; helper function to calculate the how many AND and OR operators are in the expression
 
 (= (counter $expr)
-    (if (== $expr ())
+    (if (or (== $expr ()) (== (get-metatype $expr) Symbol))
         0
         (let*
           (

--- a/scoring/fitness.metta
+++ b/scoring/fitness.metta
@@ -24,7 +24,7 @@
  ;; If a variable is not found, it is replaced with undefined.
 (= (replaceWithTruth $expr $space $spaceContent)
     (if (== (get-metatype $expr) Expression) 
-        (if (and (not (== (car-atom $expr) ())) (== (cdr-atom $expr) ())) ;; Special case: (A) → Should replace as a symbol
+        (if (== (cdr-atom $expr) ()) ;; Special case: (A) → Should replace as a symbol
             (collapse (replaceWithTruth (superpose $expr) $space $spaceContent))
             (let* (
                 ($op (car-atom $expr))
@@ -51,7 +51,7 @@
 (= (evaluate $expr)
     (if (== (get-metatype $expr) Grounded) ;; T / F
         $expr
-        (if (and (not (== (car-atom $expr) ())) (== (cdr-atom $expr) ()))  ;;  Handle (True) or (False)
+        (if (== (cdr-atom $expr) ())  ;;  Handle (True) or (False)
             (evaluate (car-atom $expr))  ;; Extract the actual boolean value
             (case (car-atom $expr) 
                 (

--- a/scoring/test/fitness-test.metta
+++ b/scoring/test/fitness-test.metta
@@ -76,3 +76,58 @@
       (True (A True) (B False) (C False) (D True)))
      0.1)
    -0.4)
+
+;; Test Case 8: Simple Expression with no connective - Symbol
+!(assertEqual 
+   (penalizedFitness 
+     (A)
+     ((True (A True))
+      (False (A False)))
+     0.1)
+   2)
+
+;; Test Case 9:
+!(assertEqual 
+   (penalizedFitness 
+     (A)
+     ((False (A True))
+      (False (A False)))
+     0.1)
+   1)
+
+;; Test Case 10: simple expression but complex data
+!(assertEqual 
+   (penalizedFitness 
+     (A)
+    ((True (A True) (B False) (C True) (D True))
+      (False (A False) (B True) (C False) (D False))
+      (True (A True) (B False) (C False) (D True)))
+     0.1)
+   3)
+
+;; Test Case 11: Simple Expression with negation
+!(assertEqual 
+   (penalizedFitness 
+     (NOT A)
+     ((False (A True))
+      (True (A False)))
+     0.1)
+   2)
+
+;; Test Case 12: Symbol
+!(assertEqual 
+   (penalizedFitness 
+     A
+     ((True (A True)))
+     0.1)
+   1)
+
+;; Test Case 13: Symbol undefined
+!(assertEqual 
+   (penalizedFitness 
+     A
+     ((True (P True)))
+     0.1)
+   0)
+
+! (ALL TEST CASES HAVE PASSED!)

--- a/scoring/test/fitness-test.metta
+++ b/scoring/test/fitness-test.metta
@@ -129,5 +129,3 @@
      ((True (P True)))
      0.1)
    0)
-
-! (ALL TEST CASES HAVE PASSED!)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Adjust the "**replaceWithTruth**", "**evaluate**" and "**count**" functions to correctly work and score symbolic expressions like (A), (NOT A), A that don't have logical connectives AND & OR.

## Motivation and Context
The already implemented fitness scoring function doesn't take into account of symbolic expressions and run into issues, maybe an infinite recursion

## How Has This Been Tested?
Test cases have been added in the **fitness-test** in **test** directory covering the different scenarios. All the previous and newly test cases pass.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
