### PR TITLE
fix: Workflow to run tests using metta instead of metta-run

### DIFF
--- a/.github/workflows/MeTTa-CI.yml
+++ b/.github/workflows/MeTTa-CI.yml
@@ -25,14 +25,10 @@ jobs:
     - name: Install Python Dependencies
       run: |
         python -m pip install --upgrade pip==23.1.2
-
-    - name: install and setup metta-run script
-      run: |
-        curl -fsSL https://raw.githubusercontent.com/iCog-Labs-Dev/metta-prebuilt-binary/main/install.sh | bash
+        pip install numpy==2.2.1
+        pip install hyperon==0.1.12
+        metta --version
 
     - name: Run tests
       working-directory: ./
       run: python3 scripts/run-tests.py
-
-    - name: Ensure metta-run is executable
-      run: chmod +x $HOME/metta-bin/metta-run

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -62,7 +62,7 @@ def run_test_file(test_file):
 
     Returns:
         tuple:
-            - result (subprocess.CompletedProcess | subprocess.CalledProcessError): 
+            - result (subprocess.CompletedProcess | subprocess.CalledProcessError):
               The result of the test execution.
             - test_file (pathlib.Path): The path to the test file.
             - has_failure (bool): True if the test failed due to a `CalledProcessError`.
@@ -95,7 +95,7 @@ def print_ascii_art(text):
 
 
 # Define the command to run with the test files
-metta_run_command = "metta-run"
+metta_run_command = "metta"
 
 root = pathlib.Path("../")
 testMettaFiles = list(root.rglob("*test.metta"))
@@ -140,5 +140,3 @@ print(GREEN + f"{total_files - fails} succeeded." + RESET)
 if fails > 0:
     print(RED + "Tests failed. Process Exiting with exit code 1" + RESET)
     sys.exit(1)
-
-


### PR DESCRIPTION
Updating workflow to work by installing necessary python packages first and using hyperon's metta instead of metta-run.