### PR TITLE
Implemented an ID system for nodes in an Expression and a getNodeById function

### DIFF
--- a/utilities/moses-types.metta
+++ b/utilities/moses-types.metta
@@ -29,7 +29,10 @@
    )
    (if (== $nodeType Symbol) 
        $nodeAtIndex 
-       (getNodeById $nodeAtIndex (mkNodeId $nextIndexes))
+       (if (== $nextIndexes ()) 
+           $nodeAtIndex
+           (getNodeById $nodeAtIndex (mkNodeId $nextIndexes))
+       )
    )
 )
 )

--- a/utilities/moses-types.metta
+++ b/utilities/moses-types.metta
@@ -1,0 +1,35 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;       NodeId           ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; (i i i ...) : the id would be in the form of a tuple
+; it contains a list of indexes the node is found starting from the outer 
+; Ex: (AND (OR A B) (OR C D))
+;     AND -> 0
+;      A  -> (1 0)
+;      C  -> (2 1)
+
+(: NodeId Type)
+(: mkNodeId (-> $tuple NodeId))
+(= (mkNodeId $tuple) $tuple)
+(: Node Type)
+
+;;Finds and returns a specific node from an expressions using its NodeId
+;;   params: $exp: the expression
+;;           $NodeId: the NodeId of the node to be found from the $exp
+;;   returns: the node at the positions specified by the NodeId
+(: getNodeById (-> Tree NodeId Node))
+(= (getNodeById $exp $NodeId)
+(let* 
+   (
+      ($index (car-atom $NodeId))
+      ($nodeAtIndex (index-atom $exp $index))
+      ($nodeType (get-metatype $nodeAtIndex))
+      ($nextIndexes (cdr-atom $NodeId))
+   )
+   (if (== $nodeType Symbol) 
+       $nodeAtIndex 
+       (getNodeById $nodeAtIndex (mkNodeId $nextIndexes))
+   )
+)
+)

--- a/utilities/tests/moses-types-test.metta
+++ b/utilities/tests/moses-types-test.metta
@@ -3,16 +3,14 @@
 
 ;output test
 ! (assertEqual (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (0))) AND)
-! (assertEqual (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (1 0))) OR)
+! (assertEqual (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (1))) (OR A B))
 ! (assertEqual (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (1 2))) B)
-! (assertEqual (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (2 1))) C)
+! (assertEqual (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (2 2))) (AND D E))
 ! (assertEqual (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (2 2 2))) E)
 
 ;type test
 ! (assertEqual (get-type (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (0)))) Node)
-! (assertEqual (get-type (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (1 0)))) Node)
+! (assertEqual (get-type (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (1)))) Node)
 ! (assertEqual (get-type (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (1 2)))) Node)
-! (assertEqual (get-type (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (2 1)))) Node)
+! (assertEqual (get-type (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (2 2)))) Node)
 ! (assertEqual (get-type (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (2 2 2)))) Node)
-
-

--- a/utilities/tests/moses-types-test.metta
+++ b/utilities/tests/moses-types-test.metta
@@ -1,0 +1,18 @@
+!(register-module! ../../../metta-moses)
+! (import! &self metta-moses:utilities:moses-types)
+
+;output test
+! (assertEqual (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (0))) AND)
+! (assertEqual (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (1 0))) OR)
+! (assertEqual (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (1 2))) B)
+! (assertEqual (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (2 1))) C)
+! (assertEqual (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (2 2 2))) E)
+
+;type test
+! (assertEqual (get-type (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (0)))) Node)
+! (assertEqual (get-type (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (1 0)))) Node)
+! (assertEqual (get-type (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (1 2)))) Node)
+! (assertEqual (get-type (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (2 1)))) Node)
+! (assertEqual (get-type (getNodeById (AND (OR A B) (OR C (AND D E))) (mkNodeId (2 2 2)))) Node)
+
+


### PR DESCRIPTION
## Description
- I have implemented a type called NodeId, a tuple of indexes uniquely identifying a node in an expression. It uses the built-in method index-atom to do so. 
- I have also created a function getNodeById, which takes an expression and a NodeId to return a specific node found at the position specified by the NodeId. 

## Motivation and Context
These changes will help us to specify positions in a tree for example when creating knobs at specific knob positions and so on.

## How Has This Been Tested?
The code has been tested inside the tests folder using assertEqual. 
I tested it in meTTa 0.2.3 environment using different test cases for possible node positions. I have also tested the types returned by the function and it works as expected. The changes made don't affect other areas of our codebase.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
