### PR TITLE
fixed the issue on concatTuple function

### DIFF
--- a/pyvenv.cfg
+++ b/pyvenv.cfg
@@ -1,3 +1,0 @@
-home = /usr/bin
-include-system-site-packages = false
-version = 3.10.12

--- a/pyvenv.cfg
+++ b/pyvenv.cfg
@@ -1,0 +1,3 @@
+home = /usr/bin
+include-system-site-packages = false
+version = 3.10.12

--- a/utilities/general-helpers.metta
+++ b/utilities/general-helpers.metta
@@ -9,7 +9,8 @@
 
 ;Function to cocatinate two tuples (A B) (C D) ==> (A B C D)
 ;; (: concatTuple (-> Expression Expression Expression))
- (= (concatTuple $x $y) (collapse (union (superpose $x) (superpose $y)))) ;; FIX: No longer working on version 0.2.3
+;  (= (concatTuple $x $y) (collapse (union (superpose $x) (superpose $y)))) ;; FIX: No longer working on version 0.2.3
+(= (concatTuple $x $y) (union-atom $x $y)) ;; This should work when run after activating the virtual env
 (: ++ (-> Expression Expression Expression))
 (= (++ $x $y)
    (case ((isSymbol $x) (isSymbol $y))

--- a/utilities/general-helpers.metta
+++ b/utilities/general-helpers.metta
@@ -9,7 +9,6 @@
 
 ;Function to cocatinate two tuples (A B) (C D) ==> (A B C D)
 ;; (: concatTuple (-> Expression Expression Expression))
-;  (= (concatTuple $x $y) (collapse (union (superpose $x) (superpose $y)))) ;; FIX: No longer working on version 0.2.3
 (= (concatTuple $x $y) (union-atom $x $y)) ;; This should work when run after activating the virtual env
 (: ++ (-> Expression Expression Expression))
 (= (++ $x $y)

--- a/utilities/tests/general-helper-functions-test.metta
+++ b/utilities/tests/general-helper-functions-test.metta
@@ -10,11 +10,11 @@
 !(assertEqualToResult (~= Something Something) (False))
 !(assertEqualToResult (~= Something something) (True))
 
-;; ;; Tests for the function 'concatTuple' ;; FIX: Failing Test case
-;; !(assertEqualToResult (concatTuple () (3 4)) ((3 4)))
-;; !(assertEqualToResult (concatTuple (1 2) (3 4)) ((1 2 3 4)))
-;; !(assertEqualToResult (concatTuple (1 2) ()) ((1 2)))
-;; !(assertEqualToResult (concatTuple () ()) (()))
+;; ;; Tests for the function 'concatTuple' ;; FIXED failing tests
+!(assertEqualToResult (concatTuple () (3 4)) ((3 4)))
+!(assertEqualToResult (concatTuple (1 2) (3 4)) ((1 2 3 4)))
+!(assertEqualToResult (concatTuple (1 2) ()) ((1 2)))
+!(assertEqualToResult (concatTuple () ()) (()))
 
 ;; Tests for the function 'Not'
 !(assertEqualToResult (Not (Not (Not A))) ((NOT A)))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The concatTuple wasn't working in the previous non-deterministic implementation with the new version. The changed implementation now utilizes the ```union-atom``` to concat the two tuples given while also preserving their order. However this implementation only works if the script is run inside the virtual environment using just ```metta``` instead of ```metta-run``` 

## How Has This Been Tested?
By running the commented test cases inside ```utilities/tests/general-helper-functions-test.metta``` you'll see that it passes all the test cases

Closes #204 
