### PR TITLE
Refactoring the concatTuple function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .vscode/
 venv
 
+myTest.metta
+myTest*
+
+todo

--- a/optimization/pge/pge2.metta
+++ b/optimization/pge/pge2.metta
@@ -335,7 +335,7 @@
             (($head $tail) (splitAt $rand $p1))
             (($head2 $tail2) (splitAt $rand $p2))
         )
-        (concatTuple $head $tail2)
+        (++ $head $tail2)
 
     )
 )

--- a/optimization/sggp/sggp-algorithm-with-tests.metta
+++ b/optimization/sggp/sggp-algorithm-with-tests.metta
@@ -153,7 +153,7 @@
             (if (== (get-metatype $head) Expression)
                 (let* (
                     ($recur-result (getRelations $head ()))
-                    ($newAccum (concatTuple $accum $recur-result))
+                    ($newAccum (++ $accum $recur-result))
                 )
                     (getRelations $tail $newAccum)
                 )

--- a/reduct/boolean-reduct/cut-unnecessary-or.metta
+++ b/reduct/boolean-reduct/cut-unnecessary-or.metta
@@ -43,7 +43,7 @@
               ($literals (getLiterals $exp))
               ($children (getChildren $exp))
             )
-            (concatTuple $literals $children)
+            (++ $literals $children)
           )
         )
      )

--- a/reduct/boolean-reduct/delete-inconsistent-handle.metta
+++ b/reduct/boolean-reduct/delete-inconsistent-handle.metta
@@ -17,7 +17,7 @@
     (let*
         (
           ($guardSet (getGuardSet $current))
-          ($handleSet (concatTuple $dominantSet $guardSet))
+          ($handleSet (++ $dominantSet $guardSet))
           ($isConsistent (isConsistentExp $handleSet))
         )
         (if $isConsistent ($parent $current False) ((removeElement ($current) $parent) () True)) ;; Remove current from parent.

--- a/reduct/boolean-reduct/gather-junctors.metta
+++ b/reduct/boolean-reduct/gather-junctors.metta
@@ -4,10 +4,10 @@
       (
          (($op $a $b)
             (if (== $prev ())
-               (concatTuple ($op) (concatTuple (gatherJunctors $a $op) (gatherJunctors $b $op)))
+               (++ ($op) (++ (gatherJunctors $a $op) (gatherJunctors $b $op)))
                (if (== $op $prev)
-                  (concatTuple (gatherJunctors $a $op) (gatherJunctors $b $op))
-                  ((concatTuple ($op) (concatTuple (gatherJunctors $a $op) (gatherJunctors $b $op))))
+                  (++ (gatherJunctors $a $op) (gatherJunctors $b $op))
+                  ((++ ($op) (++ (gatherJunctors $a $op) (gatherJunctors $b $op))))
                )
             )
          )

--- a/reduct/boolean-reduct/promote-common-constraints.metta
+++ b/reduct/boolean-reduct/promote-common-constraints.metta
@@ -32,7 +32,7 @@
                       ;; (() (println! (Removing Common Literals: $common)))
                       ($updatedChildren (removeCommonLiterals $common $children))
                       ($updatedLiterals (removeElement $common $literals))
-                      ($newExp (concatTuple $updatedLiterals $updatedChildren ))
+                      ($newExp (++ $updatedLiterals $updatedChildren ))
 
                       ($newCurrent (cons-atom OR $newExp))
                       ($updatedParent (findAndReplace $current $newCurrent $parent))

--- a/reduct/boolean-reduct/reduce-to-elegance.metta
+++ b/reduct/boolean-reduct/reduce-to-elegance.metta
@@ -45,7 +45,7 @@
                       ($updatedGuardSet' (setDifference $updatedGuardSet $commandSet)) ;; Apply 1-Constraint-Complement-Subtraction
                       ($appliedRedundantOr1CC (or (~= $updatedGuardSet $guardSet) (~= $updatedGuardSet' $updatedGuardSet))) ;; Storing this state to return boolean indicating RTE is applied or not.
 
-                      ($updatedSubExpression (concatTuple $updatedGuardSet' $children))
+                      ($updatedSubExpression (++ $updatedGuardSet' $children))
                       ($updatedCurrent (cons-atom AND $updatedSubExpression))
                       ($updatedParent (findAndReplace $current $updatedCurrent $parent))
 
@@ -353,7 +353,7 @@
               ($filteredGuardSet (if (~= $parentGuardSet ()) (removeElement ($child) $parentGuardSet) ()))
               ($filteredSiblings (if (~= $siblings ()) (collapse (filterTerminalAndNode (superpose $siblings))) ()))
               ($siblingsGuardSet (if (~= $filteredSiblings ()) (collapse (getGuardSetND (superpose $filteredSiblings))) ()))
-              ($totalGuardSet (concatTuple $filteredGuardSet $siblingsGuardSet))
+              ($totalGuardSet (++ $filteredGuardSet $siblingsGuardSet))
               ($localCommandSet (collapse (unique (union (superpose $totalGuardSet) (superpose $commandSet)))))
 
               ;; (() (println! (=== LocalCommandSet Log ===)))

--- a/reduct/boolean-reduct/rte-helpers.metta
+++ b/reduct/boolean-reduct/rte-helpers.metta
@@ -35,9 +35,9 @@
      (
         ($op (car-atom $exp))
         ($guardSet (getLiterals $exp))
-        ($newGuardSet (concatTuple $guardSet $elements))
+        ($newGuardSet (++ $guardSet $elements))
         ($newGuardSet' (collapse (unique (superpose $newGuardSet))))
-        ($updatedSubExpression (concatTuple $newGuardSet' (getChildren $exp)))
+        ($updatedSubExpression (++ $newGuardSet' (getChildren $exp)))
 
         ($newExp (cons-atom $op $updatedSubExpression))
      )
@@ -74,8 +74,8 @@
      (
         ($op (car-atom $exp))
         ($oldChildren (getChildren $exp))
-        ($newChildren (concatTuple $oldChildren $children))
-        ($updatedSubExpression (concatTuple (getLiterals $exp) $newChildren))
+        ($newChildren (++ $oldChildren $children))
+        ($updatedSubExpression (++ (getLiterals $exp) $newChildren))
 
         ($newExp (cons-atom $op $updatedSubExpression))
      )

--- a/utilities/general-helpers.metta
+++ b/utilities/general-helpers.metta
@@ -7,9 +7,7 @@
 ;; (: >= (-> Number Number Bool))
 ;; (= (>= $a $b) (or (== $a $b) (> $a $b)))
 
-;Function to cocatinate two tuples (A B) (C D) ==> (A B C D)
-;; (: concatTuple (-> Expression Expression Expression))
-(= (concatTuple $x $y) (union-atom $x $y)) ;; This should work when run after activating the virtual env.
+;Function to cocatinate two tuples (A B) (C D) ==> (A B C D) ;; can also be used with atoms
 (: ++ (-> Expression Expression Expression))
 (= (++ $x $y)
    (case ((isSymbol $x) (isSymbol $y))
@@ -96,7 +94,7 @@
 )
 
 ;; Fold a tuple from right to left
-(: foldr (-> (-> $a $b $b) $b $c $d))
+(: foldr (-> (-> $a $b $b) $d $c $d)) ;; changed the parameterized type of second argument from $b to $d
 (= (foldr $f $i $xs)
    (if (== $xs ())
        $i

--- a/utilities/general-helpers.metta
+++ b/utilities/general-helpers.metta
@@ -9,7 +9,7 @@
 
 ;Function to cocatinate two tuples (A B) (C D) ==> (A B C D)
 ;; (: concatTuple (-> Expression Expression Expression))
-(= (concatTuple $x $y) (union-atom $x $y)) ;; This should work when run after activating the virtual env
+(= (concatTuple $x $y) (union-atom $x $y)) ;; This should work when run after activating the virtual env.
 (: ++ (-> Expression Expression Expression))
 (= (++ $x $y)
    (case ((isSymbol $x) (isSymbol $y))

--- a/utilities/tests/general-helper-functions-test.metta
+++ b/utilities/tests/general-helper-functions-test.metta
@@ -10,11 +10,11 @@
 !(assertEqualToResult (~= Something Something) (False))
 !(assertEqualToResult (~= Something something) (True))
 
-;; ;; Tests for the function 'concatTuple' ;; FIXED failing tests
-!(assertEqualToResult (concatTuple () (3 4)) ((3 4)))
-!(assertEqualToResult (concatTuple (1 2) (3 4)) ((1 2 3 4)))
-!(assertEqualToResult (concatTuple (1 2) ()) ((1 2)))
-!(assertEqualToResult (concatTuple () ()) (()))
+;; ;; Tests for the function 'concatTuple' ;; FIXED failing tests ;; TODO change 'concatTuple' to '++'
+!(assertEqualToResult (++ () (3 4)) ((3 4)))
+!(assertEqualToResult (++ (1 2) (3 4)) ((1 2 3 4)))
+!(assertEqualToResult (++ (1 2) ()) ((1 2)))
+!(assertEqualToResult (++ () ()) (()))
 
 ;; Tests for the function 'Not'
 !(assertEqualToResult (Not (Not (Not A))) ((NOT A)))
@@ -126,10 +126,10 @@
 !(assertEqual (((curry -) 5) 4) 1)
 
 ;; ;; Test filter function ;; FIX: Failing Test case
-;; !(assertEqual (collapse (filter isUnit (9 10 () 5 4 ()))) (() ()))
-;; !(assertEqual (collapse (filter hasOneAtom (9 10 (Hello) 5 4 (Nop) ()))) ((Hello) (Nop)))
-;; !(assertEqual (collapse (filter isZero (9 10 0 5 4 0))) (0 0))
-;; !(assertEqual (collapse (filter greaterThanTen (9 10 12 5 4 28))) (12 28))
+; !(assertEqual (collapse (filter isUnit (9 10 () 5 4 ()))) (() ()))
+; !(assertEqual (collapse (filter hasOneAtom (9 10 (Hello) 5 4 (Nop) ()))) ((Hello) (Nop)))
+; !(assertEqual (collapse (filter isZero (9 10 0 5 4 0))) (0 0))
+; !(assertEqual (collapse (filter greaterThanTen (9 10 12 5 4 28))) (12 28))
 
 ;; Test wrapper function for filter function
 !(assertEqual (wrapper isZero 0) 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Found that the ```++``` function inside the general helpers file is able to achieve the purpose of the ```concatTuple```, thus keeping that function will only result in redundancy therefore I've refactored all the function calls for the ```concatTuple``` to ```++``` in all the files including the optimization and reduction components

## How Has This Been Tested?
Run the tests inside general helpers test file, that was previously for the ```concatTuple``` function.