### PR TITLE
MultiMap implementation

### DIFF
--- a/utilities/ordered-multimap.metta
+++ b/utilities/ordered-multimap.metta
@@ -1,57 +1,57 @@
 ;; Ordered multimap Data Structure
-(: OMM (-> ($k $v) Type))
-(: NilOMM (OMM ($k $v)))
-(: ConsOMM (-> ($k $v) (OMM ($k $v)) (OMM ($k $v))))
+(: MultiMap (-> ($k $v) Type))
+(: NilMMap (MultiMap ($k $v)))
+(: ConsMMap (-> ($k $v) (MultiMap ($k $v)) (MultiMap ($k $v))))
 
 ;; insert an element to the Ordered multimap
-(: OMM.insert (-> ($k $v) (OMM ($k $v)) (OMM ($k $v))))
-(= (OMM.insert ($key $value) NilOMM) (ConsOMM ($key $value) NilOMM))
-(= (OMM.insert ($key $value) (ConsOMM ($curKey $curVal) $tail))
+(: MultiMap.insert (-> ($k $v) (MultiMap ($k $v)) (MultiMap ($k $v))))
+(= (MultiMap.insert ($key $value) NilMMap) (ConsMMap ($key $value) NilMMap))
+(= (MultiMap.insert ($key $value) (ConsMMap ($curKey $curVal) $tail))
         (if (<= $key $curKey)
-            (ConsOMM ($key $value) (ConsOMM ($curKey $curVal) $tail))
-            (ConsOMM ($curKey $curVal) (OMM.insert ($key $value) $tail))))
+            (ConsMMap ($key $value) (ConsMMap ($curKey $curVal) $tail))
+            (ConsMMap ($curKey $curVal) (MultiMap.insert ($key $value) $tail))))
 
 ;; Get the first found value with the given key from the Ordered multimap using key
-(: OMM.findOne (-> $k (OMM ($k $v)) $v))
-(= (OMM.findOne $key NilOMM) (Error $key "not found"))
-(= (OMM.findOne $key (ConsOMM ($curKey $curVal) $tail))
-    (if (== $key $curKey) $curVal (OMM.findOne $key $tail) ))
+(: MultiMap.findOne (-> $k (MultiMap ($k $v)) $v))
+(= (MultiMap.findOne $key NilMMap) (Error $key "not found"))
+(= (MultiMap.findOne $key (ConsMMap ($curKey $curVal) $tail))
+    (if (== $key $curKey) $curVal (MultiMap.findOne $key $tail) ))
 
 ;; Get all found values with the given key from the Ordered multimap using key
-(: OMM.findAll (-> $k (OMM ($k $v)) Expression))
-(= (OMM.findAll $key NilOMM) ())
-(= (OMM.findAll $key (ConsOMM ($curKey $curVal) $tail)) 
+(: MultiMap.findAll (-> $k (MultiMap ($k $v)) Expression))
+(= (MultiMap.findAll $key NilMMap) ())
+(= (MultiMap.findAll $key (ConsMMap ($curKey $curVal) $tail)) 
     (if (== $key $curKey)
-        (let $rest (OMM.findAll $key $tail) (cons-atom $curVal $rest)) 
-        (OMM.findAll $key $tail)))
+        (let $rest (MultiMap.findAll $key $tail) (cons-atom $curVal $rest)) 
+        (MultiMap.findAll $key $tail)))
 
 ;; Check if a key is in the Ordered multimap
-(: OMM.contains (-> $k (OMM ($k $v)) Bool))
-(= (OMM.contains $key NilOMM) False)
-(= (OMM.contains $key (ConsOMM ($curKey $curVal) $tail))
-    (if (== $key $curKey) True (OMM.contains $key $tail)))
+(: MultiMap.contains (-> $k (MultiMap ($k $v)) Bool))
+(= (MultiMap.contains $key NilMMap) False)
+(= (MultiMap.contains $key (ConsMMap ($curKey $curVal) $tail))
+    (if (== $key $curKey) True (MultiMap.contains $key $tail)))
 
 ;; Check if a value in the Ordered multimap 
-(: OMM.checkValue (-> $v (OMM ($k $v)) Bool))
-(= (OMM.checkValue $value NilOMM) False)
-(= (OMM.checkValue $value (ConsOMM ($curKey $curVal) $tail))
-        (if (== $value $curVal) True (OMM.checkValue $value $tail)))
+(: MultiMap.checkValue (-> $v (MultiMap ($k $v)) Bool))
+(= (MultiMap.checkValue $value NilMMap) False)
+(= (MultiMap.checkValue $value (ConsMMap ($curKey $curVal) $tail))
+        (if (== $value $curVal) True (MultiMap.checkValue $value $tail)))
 
 
 ;; Remove a key-value pair with a given key from the Ordered multimap
-(: OMM.removeOne (-> $k (OMM ($k $v)) (OMM ($k $v))))
-(= (OMM.removeOne $key NilOMM) (Error $key "not found"))
-(= (OMM.removeOne $key (ConsOMM ($curKey $curVal) $tail)) 
-    (if (== $key $curKey) $tail (ConsOMM ($curKey $curVal) (OMM.removeOne $key $tail))))
+(: MultiMap.removeOne (-> $k (MultiMap ($k $v)) (MultiMap ($k $v))))
+(= (MultiMap.removeOne $key NilMMap) (Error $key "not found"))
+(= (MultiMap.removeOne $key (ConsMMap ($curKey $curVal) $tail)) 
+    (if (== $key $curKey) $tail (ConsMMap ($curKey $curVal) (MultiMap.removeOne $key $tail))))
 
 ;; Remove all key-value pair with a given key from the Ordered multimap
-(: OMM.removeAll (-> $k (OMM ($k $v)) (OMM ($k $v))))
-(= (OMM.removeAll $key NilOMM) NilOMM)
-(= (OMM.removeAll $key (ConsOMM ($curKey $curVal) $tail)) 
-    (if (== $key $curKey) (OMM.removeAll $key $tail) (ConsOMM ($curKey $curVal) (OMM.removeAll $key $tail))))
+(: MultiMap.removeAll (-> $k (MultiMap ($k $v)) (MultiMap ($k $v))))
+(= (MultiMap.removeAll $key NilMMap) NilMMap)
+(= (MultiMap.removeAll $key (ConsMMap ($curKey $curVal) $tail)) 
+    (if (== $key $curKey) (MultiMap.removeAll $key $tail) (ConsMMap ($curKey $curVal) (MultiMap.removeAll $key $tail))))
     
 ;; Get the length of the Ordered multimap
-(: OMM.length (-> (OMM ($k $v)) Number))
-(= (OMM.length NilOMM) 0)
-(= (OMM.length (ConsOMM ($curKey $curVal) $tail)) (+ 1 (OMM.length $tail)))
+(: MultiMap.length (-> (MultiMap ($k $v)) Number))
+(= (MultiMap.length NilMMap) 0)
+(= (MultiMap.length (ConsMMap ($curKey $curVal) $tail)) (+ 1 (MultiMap.length $tail)))
 

--- a/utilities/ordered-multimap.metta
+++ b/utilities/ordered-multimap.metta
@@ -1,0 +1,57 @@
+;; Ordered multimap Data Structure
+(: OMM (-> ($k $v) Type))
+(: NilOMM (OMM ($k $v)))
+(: ConsOMM (-> ($k $v) (OMM ($k $v)) (OMM ($k $v))))
+
+;; insert an element to the Ordered multimap
+(: OMM.insert (-> ($k $v) (OMM ($k $v)) (OMM ($k $v))))
+(= (OMM.insert ($key $value) NilOMM) (ConsOMM ($key $value) NilOMM))
+(= (OMM.insert ($key $value) (ConsOMM ($curKey $curVal) $tail))
+        (if (<= $key $curKey)
+            (ConsOMM ($key $value) (ConsOMM ($curKey $curVal) $tail))
+            (ConsOMM ($curKey $curVal) (OMM.insert ($key $value) $tail))))
+
+;; Get the first found value with the given key from the Ordered multimap using key
+(: OMM.findOne (-> $k (OMM ($k $v)) $v))
+(= (OMM.findOne $key NilOMM) (Error $key "not found"))
+(= (OMM.findOne $key (ConsOMM ($curKey $curVal) $tail))
+    (if (== $key $curKey) $curVal (OMM.findOne $key $tail) ))
+
+;; Get all found values with the given key from the Ordered multimap using key
+(: OMM.findAll (-> $k (OMM ($k $v)) Expression))
+(= (OMM.findAll $key NilOMM) ())
+(= (OMM.findAll $key (ConsOMM ($curKey $curVal) $tail)) 
+    (if (== $key $curKey)
+        (let $rest (OMM.findAll $key $tail) (cons-atom $curVal $rest)) 
+        (OMM.findAll $key $tail)))
+
+;; Check if a key is in the Ordered multimap
+(: OMM.contains (-> $k (OMM ($k $v)) Bool))
+(= (OMM.contains $key NilOMM) False)
+(= (OMM.contains $key (ConsOMM ($curKey $curVal) $tail))
+    (if (== $key $curKey) True (OMM.contains $key $tail)))
+
+;; Check if a value in the Ordered multimap 
+(: OMM.checkValue (-> $v (OMM ($k $v)) Bool))
+(= (OMM.checkValue $value NilOMM) False)
+(= (OMM.checkValue $value (ConsOMM ($curKey $curVal) $tail))
+        (if (== $value $curVal) True (OMM.checkValue $value $tail)))
+
+
+;; Remove a key-value pair with a given key from the Ordered multimap
+(: OMM.removeOne (-> $k (OMM ($k $v)) (OMM ($k $v))))
+(= (OMM.removeOne $key NilOMM) (Error $key "not found"))
+(= (OMM.removeOne $key (ConsOMM ($curKey $curVal) $tail)) 
+    (if (== $key $curKey) $tail (ConsOMM ($curKey $curVal) (OMM.removeOne $key $tail))))
+
+;; Remove all key-value pair with a given key from the Ordered multimap
+(: OMM.removeAll (-> $k (OMM ($k $v)) (OMM ($k $v))))
+(= (OMM.removeAll $key NilOMM) NilOMM)
+(= (OMM.removeAll $key (ConsOMM ($curKey $curVal) $tail)) 
+    (if (== $key $curKey) (OMM.removeAll $key $tail) (ConsOMM ($curKey $curVal) (OMM.removeAll $key $tail))))
+    
+;; Get the length of the Ordered multimap
+(: OMM.length (-> (OMM ($k $v)) Number))
+(= (OMM.length NilOMM) 0)
+(= (OMM.length (ConsOMM ($curKey $curVal) $tail)) (+ 1 (OMM.length $tail)))
+

--- a/utilities/tests/ordered-multimap-test.metta
+++ b/utilities/tests/ordered-multimap-test.metta
@@ -1,0 +1,44 @@
+!(register-module! ../../../metta-moses)
+
+! (import! &self metta-moses:utilities:ordered-multimap)
+
+;; Testcase OMM.insert
+! (assertEqual (OMM.insert (4 d) (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM)))))
+! (assertEqual (OMM.insert (1 e) (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) (ConsOMM (1 e) (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))))
+! (assertEqual (OMM.insert (2 b) NilOMM) (ConsOMM (2 b)  NilOMM))
+
+;; Testcase for OMM.findOne
+! (assertEqual (OMM.findOne 1 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) a)
+! (assertEqual (OMM.findOne 2 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (2 c) NilOMM)))) b)
+! (assertEqual (OMM.findOne 6 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) (Error 6 "not found"))
+
+;; Testcase for OMM.findAll
+! (assertEqual (OMM.findAll 1 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) (a))
+! (assertEqual (OMM.findAll 2 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (2 c)(ConsOMM (2 b) (ConsOMM (2 d) NilOMM)))))) (b c b d))
+! (assertEqual (OMM.findAll 6 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) ())
+
+;; Testcase for OMM.removeOne
+! (assertEqual (OMM.removeOne 5 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) (Error 5 "not found"))
+! (assertEqual (OMM.removeOne 1 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM))))) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM))))
+! (assertEqual (OMM.removeOne 2 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (2 c) NilOMM)))) (ConsOMM (1 a) (ConsOMM (2 c) NilOMM)))
+
+;; Testcase for OMM.removeAll
+! (assertEqual (OMM.removeAll 5 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM))))
+! (assertEqual (OMM.removeAll 1 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM))))) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM))))
+! (assertEqual (OMM.removeAll 2 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (2 c) NilOMM)))) (ConsOMM (1 a) NilOMM))
+
+
+;; Testcase for OMM.contains
+! (assertEqual (OMM.contains 5 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) False)
+! (assertEqual (OMM.contains 1 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM))))) True)
+! (assertEqual (OMM.contains 2 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) True)
+
+;; Testcase for OMM.checkValue
+! (assertEqual (OMM.checkValue a (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) True)
+! (assertEqual (OMM.checkValue d (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM))))) True)
+! (assertEqual (OMM.checkValue f (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) False)
+
+;; Testcase for OMM.length
+! (assertEqual (OMM.length (ConsOMM (3 c) NilOMM)) 1)
+! (assertEqual (OMM.length (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) 3)
+! (assertEqual (OMM.length (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d)(ConsOMM (5 e) (ConsOMM (6 f) (ConsOMM (7 g) (ConsOMM (8 h) (ConsOMM (9 i) NilOMM)))))))))) 9)

--- a/utilities/tests/ordered-multimap-test.metta
+++ b/utilities/tests/ordered-multimap-test.metta
@@ -2,43 +2,43 @@
 
 ! (import! &self metta-moses:utilities:ordered-multimap)
 
-;; Testcase OMM.insert
-! (assertEqual (OMM.insert (4 d) (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM)))))
-! (assertEqual (OMM.insert (1 e) (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) (ConsOMM (1 e) (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))))
-! (assertEqual (OMM.insert (2 b) NilOMM) (ConsOMM (2 b)  NilOMM))
+;; Testcase MultiMap.insert
+! (assertEqual (MultiMap.insert (4 d) (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) (ConsMMap (4 d) NilMMap)))))
+! (assertEqual (MultiMap.insert (1 e) (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) (ConsMMap (1 e) (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))))
+! (assertEqual (MultiMap.insert (2 b) NilMMap) (ConsMMap (2 b)  NilMMap))
 
-;; Testcase for OMM.findOne
-! (assertEqual (OMM.findOne 1 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) a)
-! (assertEqual (OMM.findOne 2 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (2 c) NilOMM)))) b)
-! (assertEqual (OMM.findOne 6 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) (Error 6 "not found"))
+;; Testcase for MultiMap.findOne
+! (assertEqual (MultiMap.findOne 1 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) a)
+! (assertEqual (MultiMap.findOne 2 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (2 c) NilMMap)))) b)
+! (assertEqual (MultiMap.findOne 6 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) (Error 6 "not found"))
 
-;; Testcase for OMM.findAll
-! (assertEqual (OMM.findAll 1 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) (a))
-! (assertEqual (OMM.findAll 2 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (2 c)(ConsOMM (2 b) (ConsOMM (2 d) NilOMM)))))) (b c b d))
-! (assertEqual (OMM.findAll 6 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) ())
+;; Testcase for MultiMap.findAll
+! (assertEqual (MultiMap.findAll 1 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) (a))
+! (assertEqual (MultiMap.findAll 2 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (2 c)(ConsMMap (2 b) (ConsMMap (2 d) NilMMap)))))) (b c b d))
+! (assertEqual (MultiMap.findAll 6 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) ())
 
-;; Testcase for OMM.removeOne
-! (assertEqual (OMM.removeOne 5 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) (Error 5 "not found"))
-! (assertEqual (OMM.removeOne 1 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM))))) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM))))
-! (assertEqual (OMM.removeOne 2 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (2 c) NilOMM)))) (ConsOMM (1 a) (ConsOMM (2 c) NilOMM)))
+;; Testcase for MultiMap.removeOne
+! (assertEqual (MultiMap.removeOne 5 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) (Error 5 "not found"))
+! (assertEqual (MultiMap.removeOne 1 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) (ConsMMap (4 d) NilMMap))))) (ConsMMap (2 b) (ConsMMap (3 c) (ConsMMap (4 d) NilMMap))))
+! (assertEqual (MultiMap.removeOne 2 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (2 c) NilMMap)))) (ConsMMap (1 a) (ConsMMap (2 c) NilMMap)))
 
-;; Testcase for OMM.removeAll
-! (assertEqual (OMM.removeAll 5 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM))))
-! (assertEqual (OMM.removeAll 1 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM))))) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM))))
-! (assertEqual (OMM.removeAll 2 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (2 c) NilOMM)))) (ConsOMM (1 a) NilOMM))
+;; Testcase for MultiMap.removeAll
+! (assertEqual (MultiMap.removeAll 5 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap))))
+! (assertEqual (MultiMap.removeAll 1 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) (ConsMMap (4 d) NilMMap))))) (ConsMMap (2 b) (ConsMMap (3 c) (ConsMMap (4 d) NilMMap))))
+! (assertEqual (MultiMap.removeAll 2 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (2 c) NilMMap)))) (ConsMMap (1 a) NilMMap))
 
 
-;; Testcase for OMM.contains
-! (assertEqual (OMM.contains 5 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) False)
-! (assertEqual (OMM.contains 1 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM))))) True)
-! (assertEqual (OMM.contains 2 (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) True)
+;; Testcase for MultiMap.contains
+! (assertEqual (MultiMap.contains 5 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) False)
+! (assertEqual (MultiMap.contains 1 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) (ConsMMap (4 d) NilMMap))))) True)
+! (assertEqual (MultiMap.contains 2 (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) True)
 
-;; Testcase for OMM.checkValue
-! (assertEqual (OMM.checkValue a (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) True)
-! (assertEqual (OMM.checkValue d (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d) NilOMM))))) True)
-! (assertEqual (OMM.checkValue f (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) False)
+;; Testcase for MultiMap.checkValue
+! (assertEqual (MultiMap.checkValue a (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) True)
+! (assertEqual (MultiMap.checkValue d (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) (ConsMMap (4 d) NilMMap))))) True)
+! (assertEqual (MultiMap.checkValue f (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) False)
 
-;; Testcase for OMM.length
-! (assertEqual (OMM.length (ConsOMM (3 c) NilOMM)) 1)
-! (assertEqual (OMM.length (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) NilOMM)))) 3)
-! (assertEqual (OMM.length (ConsOMM (1 a) (ConsOMM (2 b) (ConsOMM (3 c) (ConsOMM (4 d)(ConsOMM (5 e) (ConsOMM (6 f) (ConsOMM (7 g) (ConsOMM (8 h) (ConsOMM (9 i) NilOMM)))))))))) 9)
+;; Testcase for MultiMap.length
+! (assertEqual (MultiMap.length (ConsMMap (3 c) NilMMap)) 1)
+! (assertEqual (MultiMap.length (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) 3)
+! (assertEqual (MultiMap.length (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) (ConsMMap (4 d)(ConsMMap (5 e) (ConsMMap (6 f) (ConsMMap (7 g) (ConsMMap (8 h) (ConsMMap (9 i) NilMMap)))))))))) 9)


### PR DESCRIPTION
## Description

This change introduces a `MultiMap` data structure that supports nested `MultiMap` values. The following methods have been implemented, all prefixed with `MultiMap.`:

* `MultiMap.insert`: Inserts a value associated with a key in order. The key can be a duplicate`.
* `MultiMap.findOne(key)`: Returns the first value (if any) associated with the key`.
* `MultiMap.findAll`: Returns an expression that contains all values associated with the key in a Map. Returns a unit atom if none exists. 
* `MultiMap.removeOne`: Removes the first value associated with the key and return the MultiMap.
* `MultiMap.removeAll`: Removes all values associated with the key and return the MultiMap.
* `MultiMap.contains`: Returns `true` if the key exists in the `MultiMap`, `false` otherwise.
* `MultiMap.checkValue`: Returns `true` if the specified value exists in the MultiMap, `false` otherwise.
* `MultiMap.length`: Returns the total number of key-value pairs in the `MultiMap`.


## Motivation and Context

This implementation addresses the need for a more versatile data structure than a standard map or multimap.


## How Has This Been Tested?

The `MultiMap` implementation has been tested using testscases

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
