### PR TITLE
Fixed: Incorrect knob construction state update handling

### DIFF
--- a/representation/knob-representation.metta
+++ b/representation/knob-representation.metta
@@ -42,3 +42,10 @@
 ;; Return: The extracted DiscKnob
 (: getDiscKnob (-> LogicalSubtreeKnob DiscreteKnob)) 
 (= (getDiscKnob (mkLSK $DiscKnob $Subtree)) $DiscKnob)
+
+;; Extracts the Tree component from a LogicalSubtreeKnob (mkLSK).
+;; Params:
+;;   $lsk: LogicalSubtreeKnob
+;; Return: The extracted Tree
+(: getTree LogicalSubtreeKnob (Tree $a))
+(= (getTree (mkLSK (mkDiscKnob (mkKnob $tree $nodeId) $multip $curr $def $dis) $sub)) $tree)

--- a/representation/logical-probe.metta
+++ b/representation/logical-probe.metta
@@ -1,23 +1,44 @@
 ;;;;;;;;;; Logical Probe ;;;;;;;;;;;
-;; Builds a tuple of LSKs by processing the sample logical perms 
+;; logicalProbe builds LSKs by processing the sampleLogicalPerms 
 ;; Params:
-;;   $exemplar: Reference tree containing the target node.
-;;   (mkNodeId $targetId): ID of the target node in the exemplar.
-;;   $perms: Tuple of expressions returns from the sampleLogicalPerms.
-;;   $addIfInExemplar: If true, include knobs even if in exemplar.
+;;      $exemplar: Reference tree containing the target node.
+;;      (mkNodeId $targetId): ID of the target node in the exemplar.
+;;      $perms: Tuple of trees
+;;      $addIfInExemplar: If true, include knobs even if in exemplar.
+;;      $knobs: the list of knobs at each iteration, () at the start
+;; Return: a tuple containing a tuple of LSKs and the final updated tree
 
-;; Return: LSKs
 
-(: logicalProbe (-> (Tree $a) NodeId Expression Bool Expression))
-(= (logicalProbe $exemplar (mkNodeId $targetId) $perms $addIfInExemplar)
+;; a helper to logicalProbe
+;; Param:
+;;   $perms: a tuple of Expressions (output of sampleLogicalPerms) 
+;; Return: a tuple of Trees
+(: permsToTree (-> Expression Expression))
+(= (permsToTree $perms)
 (collapse
+   (let*
+    (
+      ($perm (superpose $perms))
+      ($permToTree (buildTree $perm))
+    )
+    $permToTree)))
+
+;; logicalProbe
+(: logicalProbe (-> (Tree $a) NodeId Expression Bool Expression Expression))
+(= (logicalProbe $exemplar (mkNodeId $targetId) () $addIfInExemplar $knobs) ($knobs $exemplar))
+(= (logicalProbe $exemplar (mkNodeId $targetId) $perms $addIfInExemplar $knobs)
 (let*
 (
-    ($perm (superpose $perms))
-    ($permToTree (buildTree $perm))
-    ($lsk (logicalSubtreeKnob $exemplar (mkNodeId $targetId) $permToTree))
+    (($headPerms $tailPerms) (decons-atom $perms))
+    ($lsk (logicalSubtreeKnob $exemplar (mkNodeId $targetId) $headPerms))
     ($discKnob (getDiscKnob $lsk))
 )
 (if (or $addIfInExemplar (not (inExemplar $discKnob)))
-    $lsk
-    (empty)))))
+    (let* 
+    (
+        ($updatedTree (getTree $lsk))
+        ($updatedKnobs (union-atom $knobs ($lsk)))
+    )
+    (logicalProbe $updatedTree (mkNodeId $targetId) $tailPerms $addIfInExemplar $updatedKnobs)
+    )
+    (logicalProbe $exemplar (mkNodeId $targetId) $tailPerms $addIfInExemplar $knobs))))

--- a/representation/tests/knob-representation-test.metta
+++ b/representation/tests/knob-representation-test.metta
@@ -34,3 +34,21 @@
   (mkDiscKnob (mkKnob (mkTree (mkNode A) Nil) (mkNodeId (1))) (mkMultip 2) (mkDiscSpec 0) (mkDiscSpec 0) Nil))
 !(assertEqual (getDiscKnob (mkLSK (mkDiscKnob (mkKnob (mkTree (mkNode A) Nil) (mkNodeId (1))) (mkMultip 2)) (mkTree (mkNode A) Nil)))
   (mkDiscKnob (mkKnob (mkTree (mkNode A) Nil) (mkNodeId (1))) (mkMultip 2) (mkDiscSpec 0) (mkDiscSpec 0) Nil))
+
+;; getTree Tests
+!(assertEqual (getTree (mkLSK (mkDiscKnob (mkKnob (mkTree (mkNode A) Nil) (mkNodeId (1))) (mkMultip 2) (mkDiscSpec 0) (mkDiscSpec 0) Nil) (mkTree (mkNode A) Nil)))
+  (mkTree (mkNode A) Nil))
+!(assertEqual (getTree (mkLSK 
+       (mkDiscKnob 
+       (mkKnob (mkTree (mkNode AND) 
+                       (Cons (mkTree (mkNode A) 
+                             (Cons (mkNullVex (Cons (mkTree (mkNode D) Nil) Nil)) Nil)) 
+                                              (Cons (mkTree (mkNode B) Nil) Nil))) 
+               (mkNodeId (1 1))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) 
+       (mkTree (mkNode D) Nil)) )
+  (mkTree (mkNode AND) 
+                       (Cons (mkTree (mkNode A) 
+                             (Cons (mkNullVex (Cons (mkTree (mkNode D) Nil) Nil)) Nil)) 
+                                              (Cons (mkTree (mkNode B) Nil) Nil))))
+
+

--- a/representation/tests/logical-probe-test.metta
+++ b/representation/tests/logical-probe-test.metta
@@ -9,65 +9,84 @@
 !(import! &self metta-moses:utilities:nodeId)
 !(import! &self metta-moses:representation:sample-logical-perms) 
 
-;; logicalProbe Testcase 1
-!(assertEqual (=== (logicalProbe
+;; permsToTree tests
+!(assertEqual (permsToTree (A B)) ((mkTree (mkNode B) Nil) (mkTree (mkNode A) Nil)))
+!(assertEqual 
+   (permsToTree ((OR A B) (AND C D))) 
+   ((mkTree (mkNode AND) 
+            (Cons (mkTree (mkNode C) Nil) (Cons (mkTree (mkNode D) Nil) Nil))) 
+    (mkTree (mkNode OR) 
+            (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil)))))
+
+
+; logicalProbe tests
+!(assertEqual 
+    (=== (logicalProbe
       (mkTree (mkNode AND)     
         (Cons (mkTree (mkNode A) Nil)
           (Cons (mkTree (mkNode OR)
                   (Cons (mkTree (mkNode B) Nil)
                   (Cons (mkTree (mkNode C) Nil) Nil)))Nil)))
       (mkNodeId (2))           
-      ((OR C D) (AND B C))     
-      True)  
+      ((mkTree (mkNode B) Nil) (mkTree (mkNode A) Nil))    
+      True
+      ())
       
-      ((mkLSK 
-      (mkDiscKnob 
-      (mkKnob (mkTree (mkNode AND) 
-              (Cons (mkTree (mkNode A) Nil) 
-              (Cons (mkTree (mkNode OR) 
-                    (Cons (mkTree (mkNode B) Nil) 
-                    (Cons (mkTree (mkNode C) Nil) 
-                    (Cons (mkNullVex 
-                          (Cons (mkTree (mkNode AND) 
-                                (Cons (mkTree (mkNode B) Nil) 
-                                (Cons (mkTree (mkNode C) Nil) Nil))) Nil)) Nil)))) Nil))) 
-                                (mkNodeId (2 3))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) 
-     (mkTree (mkNode AND) (Cons (mkTree (mkNode B) Nil) (Cons (mkTree (mkNode C) Nil) Nil)))) 
-     
-     (mkLSK 
-     (mkDiscKnob 
-     (mkKnob (mkTree (mkNode AND) 
-             (Cons (mkTree (mkNode A) Nil) 
-             (Cons (mkTree (mkNode OR) 
-                   (Cons (mkTree (mkNode B) Nil) 
-                   (Cons (mkTree (mkNode C) Nil) 
-                   (Cons (mkNullVex (Cons (mkTree (mkNode OR) 
-                                          (Cons (mkTree (mkNode C) Nil) 
-                                          (Cons (mkTree (mkNode D) Nil) Nil))) Nil)) Nil)))) Nil))) 
-            (mkNodeId (2 3))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) 
-     (mkTree (mkNode OR) (Cons (mkTree (mkNode C) Nil) (Cons (mkTree (mkNode D) Nil) Nil)))))) True)
+      (((mkLSK 
+         (mkDiscKnob 
+           (mkKnob (mkTree (mkNode AND) 
+                           (Cons (mkTree (mkNode A) Nil) 
+                           (Cons (mkTree (mkNode OR) 
+                                 (Cons (mkTree (mkNode B) Nil) 
+                                 (Cons (mkTree (mkNode C) Nil) Nil))) Nil))) 
+                   (mkNodeId (2 1))) 
+         (mkMultip 3) (mkDiscSpec 1) (mkDiscSpec 1) Nil) 
+        (mkTree (mkNode B) Nil)) 
 
-;; logicalProbe Testcase 2
-!(assertEqual (=== (logicalProbe
-      (mkTree (mkNode AND)     
-              (Cons (mkTree (mkNode A) Nil)
-              (Cons (mkTree (mkNode B) Nil) Nil)))
+        (mkLSK 
+         (mkDiscKnob 
+          (mkKnob (mkTree (mkNode AND) 
+                  (Cons (mkTree (mkNode A) Nil) 
+                  (Cons (mkTree (mkNode OR) 
+                        (Cons (mkTree (mkNode B) Nil) 
+                        (Cons (mkTree (mkNode C) Nil) 
+                        (Cons (mkNullVex 
+                              (Cons (mkTree (mkNode A) Nil) Nil)) Nil)))) Nil))) 
+                  (mkNodeId (2 3))) 
+         (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) 
+        (mkTree (mkNode A) Nil))) 
+        
+        (mkTree (mkNode AND) 
+                (Cons (mkTree (mkNode A) Nil) 
+                (Cons (mkTree (mkNode OR) 
+                      (Cons (mkTree (mkNode B) Nil) 
+                      (Cons (mkTree (mkNode C) Nil) 
+                      (Cons (mkNullVex 
+                             (Cons (mkTree (mkNode A) Nil) Nil)) Nil)))) Nil))))) True)
+
+!(assertEqual 
+    (=== (logicalProbe
+      (mkTree (mkNode OR)
+                  (Cons (mkTree (mkNode B) Nil)
+                  (Cons (mkTree (mkNode C) Nil) Nil)))
       (mkNodeId (1))           
-      (C D)     
-      False) 
-      ((mkLSK 
-       (mkDiscKnob 
-       (mkKnob (mkTree (mkNode AND) 
-                       (Cons (mkTree (mkNode A) 
-                             (Cons (mkNullVex (Cons (mkTree (mkNode D) Nil) Nil)) Nil)) 
-                                              (Cons (mkTree (mkNode B) Nil) Nil))) 
-               (mkNodeId (1 1))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) 
-       (mkTree (mkNode D) Nil)) 
-       (mkLSK 
-       (mkDiscKnob 
-       (mkKnob (mkTree (mkNode AND) 
-               (Cons (mkTree (mkNode A) 
-               (Cons (mkNullVex (Cons (mkTree (mkNode C) Nil) Nil)) Nil)) 
-                                (Cons (mkTree (mkNode B) Nil) Nil))) 
-               (mkNodeId (1 1))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) 
-       (mkTree (mkNode C) Nil)))) True)    
+      ((mkTree (mkNode B) Nil))    
+      True
+      ())
+
+     (((mkLSK 
+        (mkDiscKnob 
+          (mkKnob (mkTree (mkNode OR) 
+                  (Cons (mkTree (mkNode B) 
+                        (Cons (mkNullVex  
+                              (Cons (mkTree (mkNode B) Nil) Nil)) Nil)) 
+                  (Cons (mkTree (mkNode C) Nil) Nil))) 
+                  (mkNodeId (1 1))) 
+          (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) 
+        (mkTree (mkNode B) Nil)))
+
+      (mkTree (mkNode OR) 
+              (Cons (mkTree (mkNode B) 
+              (Cons (mkNullVex 
+                    (Cons (mkTree (mkNode B) Nil) Nil)) Nil)) 
+        (Cons (mkTree (mkNode C) Nil) Nil))))) True)


### PR DESCRIPTION
## Description
This change has fixed the issue [Issue 229](https://github.com/iCog-Labs-Dev/metta-moses/issues/229) It makes sure that the `logicalProbe` function updates the tree each time a knob is added. And it finally returns a tuple containing the list of knobs created and the updated tree. 

## Motivation and Context
This change fixes an open issue that is linked above. 

## How Has This Been Tested?
It has been tested in metta 0.2.3 environment using similar testcases written for the previous implementation with slight modification and has passed. It doesn't affect other areas of the codebase.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix ( Closes #229 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
