### PR TITLE
addLogicalKnobs implementation

### DIFF
--- a/representation/add-logical-knobs.metta
+++ b/representation/add-logical-knobs.metta
@@ -9,8 +9,8 @@
 
 ;; helper function to the addLogicalKnobs
 ;; takes a tuple of knobs and return a tuple of knob and knobSpec pairs
-(: mkPair (-> Expression Expression))
-(= (mkPair $tuple)
+(: pairKnobWithSpec (-> Expression Expression))
+(= (pairKnobWithSpec $tuple)
 (collapse (let*
 (
     ($knob (superpose $tuple))
@@ -21,16 +21,16 @@
 
 ;; addLogicalKnobs
 (: addLogicalKnobs (-> (Tree $a) NodeId Bool (MultiMap ($k $v)) Expression))
-(= (addLogicalKnobs $exemplar (mkNodeId $targetId) $addIfInExemplar $map) 
+(= (addLogicalKnobs $exemplar $nodeId $addIfInExemplar $map) 
 (let*
 (
-  ((mkTree (mkNode $op) $children) (getNodeById $exemplar (mkNodeId $targetId)))
+  ((mkTree (mkNode $op) $children) (getNodeById $exemplar $nodeId))
   ($lengthOfArgs (len (ARGS)))
   ($perms (sampleLogicalPerms $op $lengthOfArgs))
   ($treePerms (map-atom $perms $perm (buildTree $perm)))
-  (($knobs $updatedTree) (logicalProbe $exemplar (mkNodeId $targetId) $treePerms $addIfInExemplar ()))
-  ($pairs (mkPair $knobs)) 
-  ($mmp (tupleToMMap $pairs NilMMap discSpec<=))  
+  (($knobs $updatedTree) (logicalProbe $exemplar $nodeId $treePerms $addIfInExemplar ()))
+  ($pairs (pairKnobWithSpec $knobs)) 
+  ($mmp (expToMMap $pairs NilMMap discSpec<=))  
 )
 ($updatedTree $mmp)
 )

--- a/representation/add-logical-knobs.metta
+++ b/representation/add-logical-knobs.metta
@@ -1,0 +1,37 @@
+;;;;;;;; addLogicalKnobs ;;;;;;;;;
+;; Creates and adds logical subtree knobs in to a multimap
+;; Params:
+;;   $exemplar: Reference tree containing the target node.
+;;   (mkNodeId $targetId): ID of the target node in the exemplar.
+;;   $addIfInExemplar: If true, include knobs even if in exemplar.
+;;   $map: a multimap to add the new knobs into
+;; Return: a tuple of ($knobSpec $knob) pair and the updated tree
+
+;; helper function to the addLogicalKnobs
+;; takes a tuple of knobs and return a tuple of knob and knobSpec pairs
+(: mkPair (-> Expression Expression))
+(= (mkPair $tuple)
+(collapse (let*
+(
+    ($knob (superpose $tuple))
+    ($knobSpec (getKnobSpec $knob))
+)
+($knobSpec $knob)
+)))
+
+;; addLogicalKnobs
+(: addLogicalKnobs (-> (Tree $a) NodeId Bool (MultiMap ($k $v)) Expression))
+(= (addLogicalKnobs $exemplar (mkNodeId $targetId) $addIfInExemplar $map) 
+(let*
+(
+  ((mkTree (mkNode $op) $children) (getNodeById $exemplar (mkNodeId $targetId)))
+  ($lengthOfArgs (len (ARGS)))
+  ($perms (sampleLogicalPerms $op $lengthOfArgs))
+  ($treePerms (map-atom $perms $perm (buildTree $perm)))
+  (($knobs $updatedTree) (logicalProbe $exemplar (mkNodeId $targetId) $treePerms $addIfInExemplar ()))
+  ($pairs (mkPair $knobs)) 
+  ($mmp (tupleToMMap $pairs NilMMap discSpec<=))  
+)
+($updatedTree $mmp)
+)
+)

--- a/representation/add-logical-knobs.metta
+++ b/representation/add-logical-knobs.metta
@@ -5,7 +5,7 @@
 ;;   (mkNodeId $targetId): ID of the target node in the exemplar.
 ;;   $addIfInExemplar: If true, include knobs even if in exemplar.
 ;;   $map: a multimap to add the new knobs into
-;; Return: a tuple of ($knobSpec $knob) pair and the updated tree
+;; Return: a multimap of ($knobSpec $knob) and the updated tree
 
 ;; helper function to the addLogicalKnobs
 ;; takes a tuple of knobs and return a tuple of knob and knobSpec pairs

--- a/representation/knob-representation.metta
+++ b/representation/knob-representation.metta
@@ -52,24 +52,11 @@
 
 ;; Calculates the knob Specification of an LSK
 (: getKnobSpec (-> LogicalSubtreeKnob DiscSpec))
-(= (getKnobSpec (mkLSK (mkDiscKnob $knob (mkMultip $multip) (mkDiscSpec $curr) (mkDiscSpec $def) $dis) $subtree))
+(= (getKnobSpec (mkLSK (mkDiscKnob $knob (mkMultip $multip) $curr $def $dis) $subtree))
 (mkDiscSpec (- $multip (List.length $dis))))
 
 ;; A comparison function for discSpec 
 ;; (used as a $compFunc to insert knobSpec and knob pairs into a multimap ) 
 (: discSpec<= (-> DiscSpec DiscSpec Bool))
 (= (discSpec<= (mkDiscSpec $newKey) (mkDiscSpec $currKey))
-(if (<= $newKey $currKey) True False))
-
-;; Converts a tuple of pairs into ordered multimap
-;; Ex: ((k1 v1) (k2 v2)) -> (ConsMMap (k1 v1) (ConsMMap (k2 v2) NilMMap))
-(: tupleToMMap (-> Expression (MultiMap ($k $v)) (-> $k $k Bool) (MultiMap ($k $v))))
-(= (tupleToMMap () $map $compFunc) NilMMap)
-(= (tupleToMMap $tuple $map $compFunc)
-(let*
-(
-    (($head $tail) (decons-atom $tuple))
-    ($updatedMap (MultiMap.insert $head $map $compFunc))
-
-)
-(if (== $tail ()) $updatedMap (tupleToMMap $tail $updatedMap $compFunc))))
+(<= $newKey $currKey))

--- a/representation/knob-representation.metta
+++ b/representation/knob-representation.metta
@@ -49,3 +49,26 @@
 ;; Return: The extracted Tree
 (: getTree LogicalSubtreeKnob (Tree $a))
 (= (getTree (mkLSK (mkDiscKnob (mkKnob $tree $nodeId) $multip $curr $def $dis) $sub)) $tree)
+
+(: getKnobSpec (-> LogicalSubtreeKnob DiscSpec))
+(= (getKnobSpec (mkLSK (mkDiscKnob $knob (mkMultip $multip) (mkDiscSpec $curr) (mkDiscSpec $def) $dis) $subtree))
+(mkDiscSpec (- $multip (List.length $dis))))
+
+;; A comparison function for discSpec 
+;; (used as a $compFunc to insert knobSpec and knob pairs into a multimap ) 
+(: discSpec<= (-> DiscSpec DiscSpec Bool))
+(= (discSpec<= (mkDiscSpec $newKey) (mkDiscSpec $currKey))
+(if (<= $newKey $currKey) True False))
+
+;; Converts a tuple of pairs into ordered multimap
+;; Ex: ((k1 v1) (k2 v2)) -> (ConsMMap (k1 v1) (ConsMMap (k2 v2) NilMMap))
+(: tupleToMMap (-> Expression (MultiMap ($k $v)) (-> $k $k Bool) (MultiMap ($k $v))))
+(= (tupleToMMap () $map $compFunc) NilMMap)
+(= (tupleToMMap $tuple $map $compFunc)
+(let*
+(
+    (($head $tail) (decons-atom $tuple))
+    ($updatedMap (MultiMap.insert $head $map $compFunc))
+
+)
+(if (== $tail ()) $updatedMap (tupleToMMap $tail $updatedMap $compFunc))))

--- a/representation/knob-representation.metta
+++ b/representation/knob-representation.metta
@@ -50,6 +50,7 @@
 (: getTree LogicalSubtreeKnob (Tree $a))
 (= (getTree (mkLSK (mkDiscKnob (mkKnob $tree $nodeId) $multip $curr $def $dis) $sub)) $tree)
 
+;; Calculates the knob Specification of an LSK
 (: getKnobSpec (-> LogicalSubtreeKnob DiscSpec))
 (= (getKnobSpec (mkLSK (mkDiscKnob $knob (mkMultip $multip) (mkDiscSpec $curr) (mkDiscSpec $def) $dis) $subtree))
 (mkDiscSpec (- $multip (List.length $dis))))

--- a/representation/sample-logical-perms.metta
+++ b/representation/sample-logical-perms.metta
@@ -1,6 +1,6 @@
 
 ;; sampled arguments (inputs)
-!(bind! args (A B C D E F))
+!(bind! args (A B))
 
 ;; helper function to swap operators
 (: swapAndOr (-> Atom Atom))

--- a/representation/tests/add-logical-knobs-test.metta
+++ b/representation/tests/add-logical-knobs-test.metta
@@ -1,0 +1,98 @@
+!(register-module! ../../../metta-moses)
+!(import! &self metta-moses:utilities:tree)
+!(import! &self metta-moses:utilities:list-methods)
+!(import! &self metta-moses:utilities:general-helpers)
+!(import! &self metta-moses:representation:knob-representation)
+!(import! &self metta-moses:representation:logical-probe)
+!(import! &self metta-moses:representation:knob-representation)
+!(import! &self metta-moses:representation:lsk)
+!(import! &self metta-moses:utilities:nodeId)
+!(import! &self metta-moses:representation:sample-logical-perms) 
+!(import! &self metta-moses:representation:add-logical-knobs)
+!(import! &self metta-moses:utilities:ordered-multimap) 
+(= (ARGS) args) 
+
+;; Testcase for the mkPair
+!(assertEqual (mkPair 
+       ((mkLSK 
+       (mkDiscKnob 
+       (mkKnob (mkTree (mkNode AND) 
+                       (Cons (mkTree (mkNode A) 
+                             (Cons (mkNullVex (Cons (mkTree (mkNode D) Nil) Nil)) Nil)) 
+                                              (Cons (mkTree (mkNode B) Nil) Nil))) 
+               (mkNodeId (1 1))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) (Cons (mkDiscSpec 1) Nil)) 
+       (mkTree (mkNode D) Nil))
+       
+       (mkLSK 
+       (mkDiscKnob 
+       (mkKnob (mkTree (mkNode AND) 
+                       (Cons (mkTree (mkNode A) 
+                             (Cons (mkNullVex (Cons (mkTree (mkNode D) Nil) Nil)) Nil)) 
+                                              (Cons (mkTree (mkNode B) Nil) Nil))) 
+               (mkNodeId (1 1))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) (Cons (mkDiscSpec 1) Nil)) 
+       (mkTree (mkNode D) Nil)))
+       
+       )
+       (((mkDiscSpec 2)(mkLSK 
+       (mkDiscKnob 
+       (mkKnob (mkTree (mkNode AND) 
+                       (Cons (mkTree (mkNode A) 
+                             (Cons (mkNullVex (Cons (mkTree (mkNode D) Nil) Nil)) Nil)) 
+                                              (Cons (mkTree (mkNode B) Nil) Nil))) 
+               (mkNodeId (1 1))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) (Cons (mkDiscSpec 1) Nil)) 
+       (mkTree (mkNode D) Nil)))
+       ((mkDiscSpec 2)(mkLSK 
+       (mkDiscKnob 
+       (mkKnob (mkTree (mkNode AND) 
+                       (Cons (mkTree (mkNode A) 
+                             (Cons (mkNullVex (Cons (mkTree (mkNode D) Nil) Nil)) Nil)) 
+                                              (Cons (mkTree (mkNode B) Nil) Nil))) 
+               (mkNodeId (1 1))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) (Cons (mkDiscSpec 1) Nil)) 
+       (mkTree (mkNode D) Nil))))
+       )
+
+; Testcase for the addLogicalKnobs 
+!(assertEqual (let* 
+(
+    (($updatedTree $mm) 
+     (addLogicalKnobs (mkTree (mkNode AND)     
+        (Cons (mkTree (mkNode A) Nil)
+          (Cons (mkTree (mkNode B) Nil) Nil)))
+              (mkNodeId (2)) True NilMMap))
+    ($mmpsEqual 
+     (MultiMap.equals $mm 
+     (ConsMMap ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkKnob (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) Nil)) Nil))) (mkNodeId (2 1))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))))) 
+     (ConsMMap ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkKnob (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) Nil))) Nil))) (mkNodeId (2 2))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode B) Nil) Nil))))) 
+     (ConsMMap ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkKnob (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode B) Nil) Nil)) Nil)))) Nil))) (mkNodeId (2 3))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) (mkTree (mkNode B) Nil))) 
+     (ConsMMap ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkKnob (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode A) Nil) Nil)) Nil))))) Nil))) (mkNodeId (2 4))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) (mkTree (mkNode A) Nil))) NilMMap))))))
+    ($treesEqual 
+     (== $updatedTree
+     (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode B) Nil) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode A) Nil) Nil)) Nil))))) Nil)))     )
+    )
+)
+(and $mmpsEqual $treesEqual)
+) True)
+
+; Testcase for the addLogicalKnobs 
+!(assertEqual (let* 
+(
+    (($updatedTree $mm) 
+     (addLogicalKnobs (mkTree (mkNode AND)     
+        (Cons (mkTree (mkNode A) Nil)
+          (Cons (mkTree (mkNode OR)
+                  (Cons (mkTree (mkNode B) Nil)
+                  (Cons (mkTree (mkNode C) Nil) Nil)))Nil)))
+              (mkNodeId (2)) True NilMMap))
+    ($mmpsEqual 
+     (MultiMap.equals $mm 
+     (ConsMMap ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkKnob (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode B) Nil) (Cons (mkTree (mkNode C) Nil) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) Nil)))) Nil))) (mkNodeId (2 3))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))))) 
+     (ConsMMap ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkKnob (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode B) Nil) (Cons (mkTree (mkNode C) Nil) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) Nil))))) Nil))) (mkNodeId (2 4))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode B) Nil) Nil))))) 
+     (ConsMMap ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkKnob (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode B) Nil) (Cons (mkTree (mkNode C) Nil) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) Nil))))) Nil))) (mkNodeId (2 1))) (mkMultip 3) (mkDiscSpec 1) (mkDiscSpec 1) Nil) (mkTree (mkNode B) Nil))) 
+     (ConsMMap ((mkDiscSpec 3) (mkLSK (mkDiscKnob (mkKnob (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode B) Nil) (Cons (mkTree (mkNode C) Nil) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode A) Nil) Nil)) Nil)))))) Nil))) (mkNodeId (2 5))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) (mkTree (mkNode A) Nil))) NilMMap))))))
+    ($treesEqual 
+     (== $updatedTree
+     (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode OR) (Cons (mkTree (mkNode B) Nil) (Cons (mkTree (mkNode C) Nil) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode AND) (Cons (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkTree (mkNode B) Nil) Nil))) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode A) Nil) Nil)) Nil)))))) Nil))))
+    )
+)
+(and $mmpsEqual $treesEqual)
+) True)

--- a/representation/tests/add-logical-knobs-test.metta
+++ b/representation/tests/add-logical-knobs-test.metta
@@ -12,8 +12,8 @@
 !(import! &self metta-moses:utilities:ordered-multimap) 
 (= (ARGS) args) 
 
-;; Testcase for the mkPair
-!(assertEqual (mkPair 
+;; Testcase for the pairKnobWithSpec
+!(assertEqual (pairKnobWithSpec
        ((mkLSK 
        (mkDiscKnob 
        (mkKnob (mkTree (mkNode AND) 

--- a/representation/tests/knob-representation-test.metta
+++ b/representation/tests/knob-representation-test.metta
@@ -2,6 +2,7 @@
 !(import! &self metta-moses:utilities:tree)
 !(import! &self metta-moses:utilities:list-methods)
 !(import! &self metta-moses:representation:knob-representation)
+!(import! &self metta-moses:utilities:ordered-multimap) 
 
 ! (assertEqual (let $return (mkKnob (mkTree (mkNode A) Nil) (mkNodeId (1))) $return)  
                (mkKnob (mkTree (mkNode A) Nil) (mkNodeId (1)))
@@ -51,4 +52,35 @@
                              (Cons (mkNullVex (Cons (mkTree (mkNode D) Nil) Nil)) Nil)) 
                                               (Cons (mkTree (mkNode B) Nil) Nil))))
 
+;; getKnobSpec Tests
+!(assertEqual (getKnobSpec (mkLSK 
+       (mkDiscKnob 
+       (mkKnob (mkTree (mkNode AND) 
+                       (Cons (mkTree (mkNode A) 
+                             (Cons (mkNullVex (Cons (mkTree (mkNode D) Nil) Nil)) Nil)) 
+                                              (Cons (mkTree (mkNode B) Nil) Nil))) 
+               (mkNodeId (1 1))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) (Cons (mkDiscSpec 1) Nil)) 
+       (mkTree (mkNode D) Nil))) (mkDiscSpec 2))
 
+!(assertEqual (getKnobSpec (mkLSK 
+       (mkDiscKnob 
+       (mkKnob (mkTree (mkNode AND) 
+                       (Cons (mkTree (mkNode A) 
+                             (Cons (mkNullVex (Cons (mkTree (mkNode D) Nil) Nil)) Nil)) 
+                                              (Cons (mkTree (mkNode B) Nil) Nil))) 
+               (mkNodeId (1 1))) (mkMultip 3) (mkDiscSpec 0) (mkDiscSpec 0) Nil) 
+       (mkTree (mkNode D) Nil)) ) (mkDiscSpec 3))
+
+
+;; Test for discSpec<=
+!(assertEqual (discSpec<= (mkDiscSpec 2) (mkDiscSpec 3)) True)
+!(assertEqual (discSpec<= (mkDiscSpec 3) (mkDiscSpec 2)) False)
+
+;; Test for tupleToMMap
+!(assertEqual 
+(tupleToMMap (((mkDiscSpec 1) (mkLsk1)) ((mkDiscSpec 2) (mkLsk2)) ((mkDiscSpec 3) (mkLsk3)))
+NilMMap discSpec<=)
+(ConsMMap ((mkDiscSpec 1) (mkLsk1)) (ConsMMap ((mkDiscSpec 2) (mkLsk2)) (ConsMMap ((mkDiscSpec 3) (mkLsk3)) NilMMap)))
+)
+
+!(assertEqual (tupleToMMap () NilMMap discSpec<=) NilMMap)

--- a/representation/tests/knob-representation-test.metta
+++ b/representation/tests/knob-representation-test.metta
@@ -75,12 +75,3 @@
 ;; Test for discSpec<=
 !(assertEqual (discSpec<= (mkDiscSpec 2) (mkDiscSpec 3)) True)
 !(assertEqual (discSpec<= (mkDiscSpec 3) (mkDiscSpec 2)) False)
-
-;; Test for tupleToMMap
-!(assertEqual 
-(tupleToMMap (((mkDiscSpec 1) (mkLsk1)) ((mkDiscSpec 2) (mkLsk2)) ((mkDiscSpec 3) (mkLsk3)))
-NilMMap discSpec<=)
-(ConsMMap ((mkDiscSpec 1) (mkLsk1)) (ConsMMap ((mkDiscSpec 2) (mkLsk2)) (ConsMMap ((mkDiscSpec 3) (mkLsk3)) NilMMap)))
-)
-
-!(assertEqual (tupleToMMap () NilMMap discSpec<=) NilMMap)

--- a/representation/tests/sample-logical-perms-test.metta
+++ b/representation/tests/sample-logical-perms-test.metta
@@ -6,5 +6,5 @@
 !(import! &self metta-moses:representation:sample-logical-perms)
 
 ;; Testcase for sample-logical-perms
-! (assertEqual (length (sampleLogicalPerms And 4)) 10 )
-! (assertEqual (length (sampleLogicalPerms OR 3)) 9 )
+! (assertEqual (length (sampleLogicalPerms And 2)) 4)
+! (assertEqual (length (sampleLogicalPerms OR 2)) 4)

--- a/utilities/general-helpers.metta
+++ b/utilities/general-helpers.metta
@@ -549,3 +549,16 @@
         (let ($head $tail) (decons-atom $expr)  (Cons $head (exprToList $tail)))
     )
 )
+
+;; Converts a tuple of pairs into ordered multimap
+;; Ex: ((k1 v1) (k2 v2)) -> (ConsMMap (k1 v1) (ConsMMap (k2 v2) NilMMap))
+(: expToMMap (-> Expression (MultiMap ($k $v)) (-> $k $k Bool) (MultiMap ($k $v))))
+(= (expToMMap () $map $compFunc) NilMMap)
+(= (expToMMap $tuple $map $compFunc)
+(let*
+(
+    (($head $tail) (decons-atom $tuple))
+    ($updatedMap (MultiMap.insert $head $map $compFunc))
+
+)
+(if (== $tail ()) $updatedMap (expToMMap $tail $updatedMap $compFunc))))

--- a/utilities/ordered-multimap.metta
+++ b/utilities/ordered-multimap.metta
@@ -59,7 +59,7 @@
 (= (MultiMap.length NilMMap) 0)
 (= (MultiMap.length (ConsMMap ($curKey $curVal) $tail)) (+ 1 (MultiMap.length $tail)))
 
-;; Check if an element in the Ordered multimap 
+;; Check if an element is found in the Ordered multimap 
 (: MultiMap.checkElement (-> ($k $v) (MultiMap ($k $v)) Bool))
 (= (MultiMap.checkElement $element NilMMap) False)
 (= (MultiMap.checkElement $element (ConsMMap $head $tail))

--- a/utilities/ordered-multimap.metta
+++ b/utilities/ordered-multimap.metta
@@ -59,3 +59,17 @@
 (= (MultiMap.length NilMMap) 0)
 (= (MultiMap.length (ConsMMap ($curKey $curVal) $tail)) (+ 1 (MultiMap.length $tail)))
 
+;; Check if an element in the Ordered multimap 
+(: MultiMap.checkElement (-> ($k $v) (MultiMap ($k $v)) Bool))
+(= (MultiMap.checkElement $element NilMMap) False)
+(= (MultiMap.checkElement $element (ConsMMap $head $tail))
+        (if (== $element $head) True (MultiMap.checkElement $element $tail)))
+
+;; Check if two multimaps are equal regardless of the order of the elements
+(: MultiMap.equals (-> (MultiMap ($k $v)) (MultiMap ($k $v)) Bool))
+(= (MultiMap.equals () $mm2) False)
+(= (MultiMap.equals (ConsMMap $x $xs) $mm2)
+(if (== (MultiMap.length (ConsMMap $x $xs)) (MultiMap.length $mm2))
+    (if (MultiMap.checkElement $x $mm2) True (MultiMap.equals $xs $mm2))
+    False
+))

--- a/utilities/tests/general-helper-functions-test.metta
+++ b/utilities/tests/general-helper-functions-test.metta
@@ -1,6 +1,9 @@
 !(register-module! ../../../metta-moses)
 
 ! (import! &self metta-moses:utilities:general-helpers)
+! (import! &self metta-moses:utilities:ordered-multimap)
+!(import! &self metta-moses:representation:knob-representation)
+
 ! (bind! &newSpace (new-space))
 
 !(assertEqualToResult (~= 1 2) (True))

--- a/utilities/tests/general-helper-functions-test.metta
+++ b/utilities/tests/general-helper-functions-test.metta
@@ -322,3 +322,12 @@
 ;; Test for exprToList
 !(assertEqual (exprToList (AND A B)) (Cons AND (Cons A (Cons B Nil))))
 !(assertEqual (exprToList (1 2 3 4)) (Cons 1 (Cons 2 (Cons 3 (Cons 4 Nil)))))
+
+;; Test for expToMMap
+!(assertEqual 
+(expToMMap (((mkDiscSpec 1) (mkLsk1)) ((mkDiscSpec 2) (mkLsk2)) ((mkDiscSpec 3) (mkLsk3)))
+NilMMap discSpec<=)
+(ConsMMap ((mkDiscSpec 1) (mkLsk1)) (ConsMMap ((mkDiscSpec 2) (mkLsk2)) (ConsMMap ((mkDiscSpec 3) (mkLsk3)) NilMMap)))
+)
+
+!(assertEqual (expToMMap () NilMMap discSpec<=) NilMMap)

--- a/utilities/tests/ordered-multimap-test.metta
+++ b/utilities/tests/ordered-multimap-test.metta
@@ -44,3 +44,13 @@
 ! (assertEqual (MultiMap.length (ConsMMap (3 c) NilMMap)) 1)
 ! (assertEqual (MultiMap.length (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) 3)
 ! (assertEqual (MultiMap.length (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) (ConsMMap (4 d)(ConsMMap (5 e) (ConsMMap (6 f) (ConsMMap (7 g) (ConsMMap (8 h) (ConsMMap (9 i) NilMMap)))))))))) 9)
+
+;; Testcase for MultiMap.checkElement
+!(assertEqual (MultiMap.checkElement (1 a) (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) True)
+!(assertEqual (MultiMap.checkElement (3 a) (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))) False)
+
+;; Testcase for MultiMap.equals
+!(assertEqual (MultiMap.equals (ConsMMap (1 a) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))
+(ConsMMap (2 b) (ConsMMap (1 a) (ConsMMap (3 c) NilMMap)))) True)
+!(assertEqual (MultiMap.equals (ConsMMap (1 b) (ConsMMap (2 b) (ConsMMap (3 c) NilMMap)))
+(ConsMMap (2 b) (ConsMMap (1 a) (ConsMMap (3 c) NilMMap)))) False)


### PR DESCRIPTION
## Description
I implemented the addLogicalKnobs functionality found in the old moses codebase. The function takes permutations from the sampleLogicalPerms function to create logicalSubtreeKnobs using each perm as a subtree. Then it accumulates each knob and its specification into a multimap. Finally, it returns the multimap and the updated tree. 

## Motivation and Context
This change will facilitate the process of knob creation and it's will be highly used but the buildLogical function which will call it iteratively. 

## How Has This Been Tested?
It has been tested inside a metta 0.2.3 environment, and all related testcases have passed without affecting other parts of the codebase.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
