### PR TITLE
Added Map.insetCounter function to insert elements into a map, updati…

### DIFF
--- a/utilities/map.metta
+++ b/utilities/map.metta
@@ -14,14 +14,14 @@
 
 ;; An insertion function that also allows map to act as a counter
 
-(: Map.insertCounter (-> ($k $v) (Map ($k $v)) (Map ($k $v))))
-(= (Map.insertCounter ($key $value) NilMap) (ConsMap ($key $value) NilMap))
-(= (Map.insertCounter ($key $value) (ConsMap ($curKey $curVal) $tail))
+(: Map.insertCounter (-> $k (Map ($k $v)) (Map ($k $v))))
+(= (Map.insertCounter $key NilMap) (ConsMap ($key 1) NilMap))
+(= (Map.insertCounter $key (ConsMap ($curKey $curVal) $tail))
     (if (== $key $curKey)
-        (ConsMap ($curKey (+ $curVal $value)) $tail)
+        (ConsMap ($curKey (+ $curVal 1)) $tail)
         (if (< $key $curKey)
-            (ConsMap ($key $value) (ConsMap ($curKey $curVal) $tail))
-            (ConsMap ($curKey $curVal) (Map.insertCounter ($key $value) $tail)))))
+            (ConsMap ($key 1) (ConsMap ($curKey $curVal) $tail))
+            (ConsMap ($curKey $curVal) (Map.insertCounter $key $tail)))))
 
 ;; insert an element to a Map using custom comparison functions (equality $ lessthan)
 (: Map.insert (-> ($k $v) (Map ($k $v)) (-> $k $k Bool) (-> $k $k Bool) (Map ($k $v))))
@@ -100,3 +100,4 @@
 
 !(Map.find (ConsMap ((0) 1) (ConsMap ((1) 2) (ConsMap ((2) 3) NilMap))) (2) )
 !(Map.getByIdx (ConsMap ((0) 1) (ConsMap ((1) 2) (ConsMap ((2) 3) NilMap))) 1)
+

--- a/utilities/map.metta
+++ b/utilities/map.metta
@@ -12,6 +12,17 @@
             (ConsMap ($key $value) (ConsMap ($curKey $curVal) $tail))
             (ConsMap ($curKey $curVal) (Map.insert ($key $value) $tail)))))
 
+;; An insertion function that also allows map to act as a counter
+
+(: Map.insertCounter (-> ($k $v) (Map ($k $v)) (Map ($k $v))))
+(= (Map.insertCounter ($key $value) NilMap) (ConsMap ($key $value) NilMap))
+(= (Map.insertCounter ($key $value) (ConsMap ($curKey $curVal) $tail))
+    (if (== $key $curKey)
+        (ConsMap ($curKey (+ $curVal $value)) $tail)
+        (if (< $key $curKey)
+            (ConsMap ($key $value) (ConsMap ($curKey $curVal) $tail))
+            (ConsMap ($curKey $curVal) (Map.insertCounter ($key $value) $tail)))))
+
 ;; insert an element to a Map using custom comparison functions (equality $ lessthan)
 (: Map.insert (-> ($k $v) (Map ($k $v)) (-> $k $k Bool) (-> $k $k Bool) (Map ($k $v))))
 (= (Map.insert ($key $value) NilMap $fEq $fLt) (ConsMap ($key $value) NilMap))
@@ -82,7 +93,7 @@
 (= (Map.find (ConsMap ($k $v) $xs) $k')
    (if (== $k $k')
        0
-       (chain (Map.find $xs $k' ) $targetIdx
+       (chain (Map.find $xs $k'' ) $targetIdx
                       (if (== $targetIdx -1)
                           $targetIdx
                           (+ 1 $targetIdx)))))

--- a/utilities/tests/map-test.metta
+++ b/utilities/tests/map-test.metta
@@ -9,10 +9,10 @@
 ! (assertEqual (Map.insert (2 b) (ConsMap (1 a) (ConsMap (3 c) (ConsMap (4 d) NilMap)))) (ConsMap (1 a) (ConsMap (2 b) (ConsMap (3 c) (ConsMap (4 d) NilMap)))))
 
 ;;Testcase for Map.insertCounter
-! (assertEqual (Map.insertCounter (1 1) (ConsMap (1 1) (ConsMap (2 2) (ConsMap (3 3) NilMap)))) (ConsMap (1 2) (ConsMap (2 2) (ConsMap (3 3) NilMap))))
-! (assertEqual (Map.insertCounter (1 1) NilMap) (ConsMap (1 1) NilMap))
-! (assertEqual (Map.insertCounter (2 5) (ConsMap (2 2) (ConsMap (3 3) NilMap))) (ConsMap (2 7) (ConsMap (3 3) NilMap)))
-! (assertEqual (Map.insertCounter (7 1) (ConsMap (1 1) (ConsMap (2 2) (ConsMap (3 3) NilMap)))) (ConsMap (1 1) (ConsMap (2 2) (ConsMap (3 3) (ConsMap (7 1) NilMap)))))
+! (assertEqual (Map.insertCounter 1 (ConsMap (1 1) (ConsMap (2 2) (ConsMap (3 3) NilMap)))) (ConsMap (1 2) (ConsMap (2 2) (ConsMap (3 3) NilMap))))
+! (assertEqual (Map.insertCounter 1 NilMap) (ConsMap (1 1) NilMap))
+! (assertEqual (Map.insertCounter 2 (ConsMap (2 2) (ConsMap (3 3) NilMap))) (ConsMap (2 3) (ConsMap (3 3) NilMap)))
+! (assertEqual (Map.insertCounter 7 (ConsMap (1 1) (ConsMap (2 2) (ConsMap (3 3) NilMap)))) (ConsMap (1 1) (ConsMap (2 2) (ConsMap (3 3) (ConsMap (7 1) NilMap)))))
 
 ;; Testcase for Map.remove
 ! (assertEqual (Map.remove 5 (ConsMap (1 a) (ConsMap (2 b) (ConsMap (3 c) NilMap)))) (Error 5 "not found"))

--- a/utilities/tests/map-test.metta
+++ b/utilities/tests/map-test.metta
@@ -8,6 +8,11 @@
 ! (assertEqual (Map.insert (1 e) (ConsMap (1 a) (ConsMap (2 b) (ConsMap (3 c) NilMap)))) (ConsMap (1 e) (ConsMap (2 b) (ConsMap (3 c) NilMap))))
 ! (assertEqual (Map.insert (2 b) (ConsMap (1 a) (ConsMap (3 c) (ConsMap (4 d) NilMap)))) (ConsMap (1 a) (ConsMap (2 b) (ConsMap (3 c) (ConsMap (4 d) NilMap)))))
 
+;;Testcase for Map.insertCounter
+! (assertEqual (Map.insertCounter (a 1) (ConsMap (a 1) (ConsMap (b 2) (ConsMap (c 3) NilMap)))) (ConsMap (a 2) (ConsMap (b 2) (ConsMap (c 3) NilMap))))
+! (assertEqual (Map.insertCounter (a 1) NilMap) (ConsMap (a 1) NilMap))
+! (assertEqual (Map.insertCounter (b 5) (ConsMap (b 2) (ConsMap (c 3) NilMap))) (ConsMap (b 7) (ConsMap (c 3) NilMap)))
+
 ;; Testcase for Map.remove
 ! (assertEqual (Map.remove 5 (ConsMap (1 a) (ConsMap (2 b) (ConsMap (3 c) NilMap)))) (Error 5 "not found"))
 ! (assertEqual (Map.remove 1 (ConsMap (1 a) (ConsMap (2 b) (ConsMap (3 c) (ConsMap (4 d) NilMap))))) (ConsMap (2 b) (ConsMap (3 c) (ConsMap (4 d) NilMap))))

--- a/utilities/tests/map-test.metta
+++ b/utilities/tests/map-test.metta
@@ -9,9 +9,10 @@
 ! (assertEqual (Map.insert (2 b) (ConsMap (1 a) (ConsMap (3 c) (ConsMap (4 d) NilMap)))) (ConsMap (1 a) (ConsMap (2 b) (ConsMap (3 c) (ConsMap (4 d) NilMap)))))
 
 ;;Testcase for Map.insertCounter
-! (assertEqual (Map.insertCounter (a 1) (ConsMap (a 1) (ConsMap (b 2) (ConsMap (c 3) NilMap)))) (ConsMap (a 2) (ConsMap (b 2) (ConsMap (c 3) NilMap))))
-! (assertEqual (Map.insertCounter (a 1) NilMap) (ConsMap (a 1) NilMap))
-! (assertEqual (Map.insertCounter (b 5) (ConsMap (b 2) (ConsMap (c 3) NilMap))) (ConsMap (b 7) (ConsMap (c 3) NilMap)))
+! (assertEqual (Map.insertCounter (1 1) (ConsMap (1 1) (ConsMap (2 2) (ConsMap (3 3) NilMap)))) (ConsMap (1 2) (ConsMap (2 2) (ConsMap (3 3) NilMap))))
+! (assertEqual (Map.insertCounter (1 1) NilMap) (ConsMap (1 1) NilMap))
+! (assertEqual (Map.insertCounter (2 5) (ConsMap (2 2) (ConsMap (3 3) NilMap))) (ConsMap (2 7) (ConsMap (3 3) NilMap)))
+! (assertEqual (Map.insertCounter (7 1) (ConsMap (1 1) (ConsMap (2 2) (ConsMap (3 3) NilMap)))) (ConsMap (1 1) (ConsMap (2 2) (ConsMap (3 3) (ConsMap (7 1) NilMap)))))
 
 ;; Testcase for Map.remove
 ! (assertEqual (Map.remove 5 (ConsMap (1 a) (ConsMap (2 b) (ConsMap (3 c) NilMap)))) (Error 5 "not found"))


### PR DESCRIPTION
### Description

Added the `Map.insetCounter` function, which inserts elements into a map by updating their counts based on occurrence frequency. This enhances the map's ability to track how many times each key appears, facilitating efficient counting operations. Additionally, test cases have been included to verify the correctness of this new functionality.

---

### Motivation and Context

This change provides a convenient way to perform counting within maps, streamlining operations that require tracking the number of occurrences of elements. It is useful for scenarios such as frequency analysis, histogram creation, and multiset implementations.

---

### How Has This Been Tested?

Test cases have been added to cover various scenarios, including inserting new elements, updating existing counts, and ensuring the correct counts are maintained after multiple insertions. Tests were run in the development environment to verify that the function behaves as expected and does not introduce regressions.

---

### Types of changes

- [x]  New feature (adds functionality)
- [ ] Bug fix (non-breaking change)
- [ ]  Breaking change (fix or feature that causes existing functionality to change)

---

### Checklist:

- [x]  My code follows the project's coding style.
- [x] I have added tests to cover my changes.
- [x] All relevant tests passed.