### PR TITLE
resizeMatapop

### DIFF
--- a/metapopulation/metapopulation.metta
+++ b/metapopulation/metapopulation.metta
@@ -1,0 +1,63 @@
+;; importing constants -- a suitable value for each of these has to be determined based on experiment
+; ! (bind! MIN-POOL-SIZE 250) ;; this is copied from the c++ implementation -- XXX a values that works best for the current implementation should be found by experrimentation??
+; ! (bind! COMP-TEMP 6.0)
+; ! (bind! CAP-COEF 50)
+
+;; python int casting function
+! (bind! int (py-atom "int"))
+
+;; Exemplar type
+(: Exemplar (-> $a Type))
+(: mkExemplar (-> (Tree $a) DemeId Cscore BehavioralScore (Exemplar $a)))
+
+;; resizeMetapop -- resizes the metapopulation so that it doesn't become too big to prorcess and too small for effective exploration as well
+;;      $nToKeep     -- the number of the top most exemplars which are exempt from removal
+;;      $minPoolSize -- protects the metapopulation against excessive trimming
+;;      $compTemp    -- used to calculate the range of scores that are likely to be preserved by the selection process
+;;      $capCoef     -- use to balance the number of individuals in the metapopulation by balancing population size so that it neither blows out the RAM or lacks enough variety -- may not even be necessary
+;;      $genCount    -- used with $capCoef in the determination of max pop allowed given the above contstraints
+(: resizeMetapop (-> (OS (Exemplar $a)) Number Number Number Number Number (OS (Exemplar $a))))
+(= (resizeMetapop (ConsOS $exemplar $rest) $nToKeep $minPoolSize $compTemp $capCoef $genCount)
+    (let ($size $capSize) ((OS.length (ConsOS $exmplar $rest)) (int (capSize $capCoef $genCount))) ;; bind two variables with two function calls 
+        (if (<= $size $minPoolSize)
+            (ConsOS $exemplar $rest)            
+            (let (mkExemplar $tree $demeId $cScore $bScore) $exemplar ;; exemplar with the best score
+            (chain (getPenScore $cScore) $topScore
+                (chain (- $topScore (usefulScoreRange $compTemp)) $worstScore
+                    (chain (getBetterCandidates (ConsOS $exemplar $rest) $worstScore) $reducedMetapop
+                        (chain (OS.length $reducedMetapop) $popSize
+                            (if (<= $popSize $capSize) 
+                                $reducedMetapop
+                                (cullAtRandom $reducedMetapop $nToKeep (- $popSize $capSize)))))))))))
+
+;; compute useful range 
+(: usefulScoreRange (-> Number Number))
+(= (usefulScoreRange $compTemp) (/ (* $compTemp 30.0) 100.0))
+
+;; calculates cap size based on number of generations -- must be recomuted based on actual data in the new implementation
+;; for the time being implement the C++ code as it
+(: capSize (-> Number Number Number))
+(= (capSize $capCoef $genCount)
+    (* (* $capCoef (+ $genCount 250)) (+ 1 (* 2 (pow-math EXP (/ (* -1 $genCount) 500))))))
+
+;; getBetterCandidates -- returns all the memmbers whose score are greater than or equal to a predetermined worst score
+(: getBetterCandidates (-> (OS (Exemplar $a)) Number (OS (Exemplar $a))))
+(= (getBetterCandidates NilOS $score) NilOS)
+(= (getBetterCandidates (ConsOS $exemplar $rest) $worstScore)
+    (let (mkExemplar $tree $demeId $cScore $bScore) $exemplar
+            (chain (getPenScore $cScore) $penScore
+        
+                (if (>= $penScore $worstScore)
+                    (ConsOS $exemplar (getBetterCandidates $rest $worstScore))
+                    NilOS))))
+
+;; cullAtRandom -- maintains the top N exemplars and removes candidates that are in the list with worse scores by chance
+;; gives a certain chance for poor candidates to survive
+(: cullAtRandom (-> (OS (Exemplar $a)) Number Number (OS (Exemplar $a))))
+(= (cullAtRandom (ConsOS $exemplar $rest) $offset $nToRemove)
+    (if (> $nToRemove 0)
+        (chain (OS.length (ConsOS $exemplar $rest)) $popSize
+            (chain (random-int &rng $offset $popSize) $index 
+                (chain (OS.removeByIdx (ConsOS $exemplar $rest) $index) $newPop
+                    (cullAtRandom $newPop $offset (- $nToRemove 1)))))
+        (ConsOS $exemplar $rest))) 

--- a/metapopulation/tests/metapopulation-test.metta
+++ b/metapopulation/tests/metapopulation-test.metta
@@ -1,0 +1,240 @@
+! (register-module! ../../../metta-moses)
+! (import! &self metta-moses:metapopulation:metapopulation)
+! (import! &self metta-moses:scoring:cscore)
+! (import! &self metta-moses:scoring:bscore)
+! (import! &self metta-moses:utilities:ordered-set)
+! (import! &self metta-moses:utilities:tree)
+
+;; Test cases for getBetterCandidates
+! (assertEqual (getBetterCandidates (ConsOS 
+      (mkExemplar 
+        (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) 
+        (mkDemeId "1") 
+        (mkCscore -0.1 2 0.1 0.1 -0.3) 
+        (mkBScore (Cons 0.5 Nil))) 
+      NilOS) -0.2) NilOS)
+
+! (assertEqual 
+      (getBetterCandidates 
+            (ConsOS 
+              (mkExemplar 
+                (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) 
+                (mkDemeId "1") 
+                (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                (mkBScore (Cons 0.5 Nil))) 
+              NilOS) 
+        -0.4) 
+              (ConsOS 
+                (mkExemplar 
+                  (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) 
+                  (mkDemeId "1") 
+                  (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                  (mkBScore (Cons 0.5 Nil))) 
+                NilOS))
+
+! (bind! pop1 (ConsOS 
+                (mkExemplar 
+                  (mkTree (mkNode XOR) (Cons (mkTree (mkNode X) Nil) (Cons (mkTree (mkNode Y) Nil) Nil))) 
+                  (mkDemeId "1") 
+                  (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                  (mkBScore (Cons 0.5 Nil))) 
+                    (ConsOS 
+                      (mkExemplar 
+                        (mkTree (mkNode AND) (Cons (mkTree (mkNode M) Nil) (Cons (mkTree (mkNode N) Nil) Nil))) 
+                        (mkDemeId "3") 
+                        (mkCscore -0.2 1 0.1 0.1 -0.4) 
+                        (mkBScore (Cons 0.3 Nil))) 
+                      (ConsOS 
+                        (mkExemplar 
+                          (mkTree (mkNode NOT) (Cons (mkTree (mkNode Z) Nil) Nil)) 
+                          (mkDemeId "2") 
+                          (mkCscore -0.5 3 0.1 0.1 -0.9) 
+                          (mkBScore (Cons 0.4 Nil))) 
+                        NilOS))))
+
+! (assertEqual (getBetterCandidates pop1 -0.5) 
+                  (ConsOS 
+                    (mkExemplar 
+                      (mkTree (mkNode XOR) (Cons (mkTree (mkNode X) Nil) (Cons (mkTree (mkNode Y) Nil) Nil))) 
+                      (mkDemeId "1") 
+                      (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                      (mkBScore (Cons 0.5 Nil))) 
+                    (ConsOS 
+                      (mkExemplar 
+                        (mkTree (mkNode AND) (Cons (mkTree (mkNode M) Nil) (Cons (mkTree (mkNode N) Nil) Nil))) 
+                        (mkDemeId "3") 
+                        (mkCscore -0.2 1 0.1 0.1 -0.4) 
+                        (mkBScore (Cons 0.3 Nil))) 
+                      NilOS)))
+! (bind! pop2 (ConsOS (mkExemplar 
+                        (mkTree (mkNode OR) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) 
+                        (mkDemeId "1") 
+                        (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                        (mkBScore (Cons 0.9 Nil))) 
+                        (ConsOS  (mkExemplar 
+                            (mkTree (mkNode NOT) (Cons (mkTree (mkNode C) Nil) Nil)) 
+                            (mkDemeId "2") 
+                            (mkCscore -0.2 3 0.1 0.1 -0.4) 
+                            (mkBScore (Cons 0.8 Nil))) 
+                          (ConsOS (mkExemplar 
+                              (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) (Cons (mkTree (mkNode E) Nil) Nil))) 
+                              (mkDemeId "3") 
+                              (mkCscore -0.3 1 0.1 0.1 -0.5) 
+                              (mkBScore (Cons 0.7 Nil))) 
+                            (ConsOS (mkExemplar 
+                                (mkTree (mkNode XOR) (Cons (mkTree (mkNode F) Nil) (Cons (mkTree (mkNode G) Nil) Nil))) 
+                                (mkDemeId "4") 
+                                (mkCscore -0.5 4 0.1 0.1 -0.7) 
+                                (mkBScore (Cons 0.6 Nil))) 
+                              (ConsOS (mkExemplar 
+                                  (mkTree (mkNode IMPLIES) (Cons (mkTree (mkNode H) Nil) (Cons (mkTree (mkNode I) Nil) Nil))) 
+                                  (mkDemeId "5") 
+                                  (mkCscore -0.6 2 0.1 0.1 -0.8) 
+                                  (mkBScore (Cons 0.5 Nil))) 
+                                (ConsOS (mkExemplar 
+                                    (mkTree (mkNode NAND) (Cons (mkTree (mkNode J) Nil) (Cons (mkTree (mkNode K) Nil) Nil))) 
+                                    (mkDemeId "6") 
+                                    (mkCscore -0.9 3 0.1 0.1 -1.1) 
+                                    (mkBScore (Cons 0.4 Nil))) 
+                                  NilOS)))))))
+! (assertEqual 
+  (getBetterCandidates pop2 -0.75) 
+              (ConsOS 
+                (mkExemplar (mkTree (mkNode OR) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) 
+                  (mkDemeId "1") 
+                  (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                  (mkBScore (Cons 0.9 Nil))) 
+                (ConsOS (mkExemplar 
+                    (mkTree (mkNode NOT) (Cons (mkTree (mkNode C) Nil) Nil)) 
+                    (mkDemeId "2") 
+                    (mkCscore -0.2 3 0.1 0.1 -0.4) 
+                    (mkBScore (Cons 0.8 Nil))) 
+                  (ConsOS (mkExemplar 
+                      (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) (Cons (mkTree (mkNode E) Nil) Nil))) 
+                      (mkDemeId "3") 
+                      (mkCscore -0.3 1 0.1 0.1 -0.5) 
+                      (mkBScore (Cons 0.7 Nil))) 
+                    (ConsOS (mkExemplar 
+                        (mkTree (mkNode XOR) (Cons (mkTree (mkNode F) Nil) (Cons (mkTree (mkNode G) Nil) Nil))) 
+                        (mkDemeId "4") 
+                        (mkCscore -0.5 4 0.1 0.1 -0.7) 
+                        (mkBScore (Cons 0.6 Nil))) 
+                      NilOS)))))
+
+;; Test cases for cullAtRandom
+! (bind! pop3 (ConsOS 
+                  (mkExemplar 
+                    (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) 
+                    (mkDemeId "1") 
+                    (mkCscore -0.1 2 0.1 0.1 -0.3) 
+                    (mkBScore (Cons 0.5 Nil))) 
+                  (ConsOS 
+                    (mkExemplar 
+                      (mkTree (mkNode NOT) (Cons (mkTree (mkNode C) Nil) Nil)) 
+                      (mkDemeId "2") 
+                      (mkCscore -0.2 1 0.1 0.1 -0.4) 
+                      (mkBScore (Cons 0.4 Nil))) 
+                    (ConsOS 
+                      (mkExemplar 
+                        (mkTree (mkNode XOR) (Cons (mkTree (mkNode D) Nil) (Cons (mkTree (mkNode E) Nil) Nil))) 
+                        (mkDemeId "3") 
+                        (mkCscore -0.3 3 0.1 0.1 -0.5) 
+                        (mkBScore (Cons 0.3 Nil))) 
+                      NilOS))))
+! (assertEqual (let $a (cullAtRandom pop3 1 2) (OS.length $a)) 1)
+
+! (bind! pop4 (ConsOS 
+        (mkExemplar 
+          (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) 
+          (mkDemeId "1") 
+          (mkCscore -0.1 2 0.1 0.1 -0.3) 
+          (mkBScore (Cons 0.5 Nil))) 
+        (ConsOS 
+          (mkExemplar 
+            (mkTree (mkNode NOT) (Cons (mkTree (mkNode C) Nil) Nil)) 
+            (mkDemeId "2") 
+            (mkCscore -0.2 1 0.1 0.1 -0.4) 
+            (mkBScore (Cons 0.4 Nil))) 
+          (ConsOS 
+            (mkExemplar 
+              (mkTree (mkNode OR) (Cons (mkTree (mkNode D) Nil) (Cons (mkTree (mkNode E) Nil) Nil))) 
+              (mkDemeId "3") 
+              (mkCscore -0.3 3 0.1 0.1 -0.5) 
+              (mkBScore (Cons 0.3 Nil))) 
+            (ConsOS 
+              (mkExemplar 
+                (mkTree (mkNode NAND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) 
+                (mkDemeId "4") 
+                (mkCscore -0.4 2 0.1 0.1 -0.6) 
+                (mkBScore (Cons 0.2 Nil))) 
+              (ConsOS 
+                (mkExemplar 
+                  (mkTree (mkNode XOR) (Cons (mkTree (mkNode C) Nil) (Cons (mkTree (mkNode D) Nil) Nil))) 
+                  (mkDemeId "5") 
+                  (mkCscore -0.5 1 0.1 0.1 -0.7) 
+                  (mkBScore (Cons 0.1 Nil))) 
+                NilOS)))))) 
+
+! (assertEqual (let $result (cullAtRandom pop4 2 2) (OS.length $result)) 3)  
+
+;; Test cases for resizeMetapop
+! (bind! pop5
+  (ConsOS 
+    (mkExemplar 
+      (mkTree (mkNode AND) (Cons (mkTree (mkNode A) Nil) (Cons (mkTree (mkNode B) Nil) Nil))) 
+      (mkDemeId "1") 
+      (mkCscore -0.1 2 0.1 0.1 -0.3) 
+      (mkBScore (Cons 0.5 Nil)))
+
+    (ConsOS 
+      (mkExemplar 
+        (mkTree (mkNode OR) (Cons (mkTree (mkNode D) Nil) (Cons (mkTree (mkNode E) Nil) Nil))) 
+        (mkDemeId "2") 
+        (mkCscore -0.2 3 0.1 0.1 -0.4) 
+        (mkBScore (Cons 0.9 Nil)))
+
+      (ConsOS 
+        (mkExemplar 
+          (mkTree (mkNode NOT) (Cons (mkTree (mkNode C) Nil) Nil)) 
+          (mkDemeId "3") 
+          (mkCscore -0.3 1 0.1 0.1 -0.5) 
+          (mkBScore (Cons 0.4 Nil)))
+
+        (ConsOS 
+          (mkExemplar 
+            (mkTree (mkNode AND) (Cons (mkTree (mkNode F) Nil) (Cons (mkTree (mkNode G) Nil) Nil))) 
+            (mkDemeId "4") 
+            (mkCscore -0.4 2 0.1 0.1 -0.6) 
+            (mkBScore (Cons 0.2 Nil)))
+
+          (ConsOS 
+            (mkExemplar 
+              (mkTree (mkNode NOT) (Cons (mkTree (mkNode A) Nil) Nil)) 
+              (mkDemeId "5") 
+              (mkCscore -0.5 1 0.1 0.1 -0.7) 
+              (mkBScore (Cons 0.1 Nil)))
+
+            (ConsOS 
+              (mkExemplar 
+                (mkTree (mkNode OR) (Cons (mkTree (mkNode B) Nil) (Cons (mkTree (mkNode C) Nil) Nil))) 
+                (mkDemeId "6") 
+                (mkCscore -0.6 3 0.1 0.1 -0.8) 
+                (mkBScore (Cons 0.8 Nil)))
+
+              (ConsOS 
+                (mkExemplar 
+                  (mkTree (mkNode AND) (Cons (mkTree (mkNode D) Nil) (Cons (mkTree (mkNode E) Nil) Nil))) 
+                  (mkDemeId "7") 
+                  (mkCscore -0.7 2 0.1 0.1 -0.9) 
+                  (mkBScore (Cons 0.7 Nil)))
+
+                (ConsOS 
+                  (mkExemplar 
+                    (mkTree (mkNode NOT) (Cons (mkTree (mkNode F) Nil) Nil)) 
+                    (mkDemeId "8") 
+                    (mkCscore -0.8 1 0.1 0.1 -1.0) 
+                    (mkBScore (Cons 0.6 Nil)))
+                  NilOS)))))))))
+
+! (assertEqual (let $a (resizeMetapop pop5 3 5 3 0.004 1000) (OS.length $a)) 6)
+! (assertEqual (let $a (resizeMetapop pop5 3 5 2 0.003 1000) (OS.length $a)) 4)

--- a/scoring/test/cscore-test.metta
+++ b/scoring/test/cscore-test.metta
@@ -39,7 +39,7 @@
 ! (assertEqual (cScore< (mkCscore -0.1 2 0.1 0.1 -0.3) (mkCscore -0.2 3 0.1 0.1 -0.4)) False)
 ! (assertEqual (cScore< (mkCscore -0.5 3 0.1 0.1 -0.7) (mkCscore -0.5 2 0.1 0.1 -0.7)) True)
 ! (assertEqual (cScore< (mkCscore -0.5 2 0.1 0.1 -0.7) (mkCscore -0.5 3 0.1 0.1 -0.7)) False)
-; ! (assertEqual (cScore< (mkCscore nan 2 0.1 0.1 -0.7) (mkCscore -0.5 3 0.1 0.1 -0.7)) True) ;; to be fixed
+! (assertEqual (cScore< (mkCscore nan 2 0.1 0.1 nan) (mkCscore -0.5 3 0.1 0.1 -0.7)) True)
 
 ;; Test cases -- composite score equality comparator 
 ! (assertEqual (cScore== (mkCscore -0.5 2 0.1 0.1 -0.7) (mkCscore -0.5 2 0.1 0.1 -0.7)) True)

--- a/utilities/ordered-set.metta
+++ b/utilities/ordered-set.metta
@@ -51,3 +51,11 @@
     (if (== $x $el)
         True
         (OS.contains $xs $el)))
+
+;; removeByIdx
+(OS.removeByIdx (-> (OS $a) Number (OS $a)))
+(= (OS.removeByIdx NilOS $index) (Error NilOS INDEX_ERROR))
+(= (OS.removeByIdx (ConsOS $x $xs) $index)
+    (if (== $index 0)
+        $xs
+        (ConsOS $x (OS.removeByIdx $xs (- $index 1)))))        

--- a/utilities/tests/ordered-set-test.metta
+++ b/utilities/tests/ordered-set-test.metta
@@ -93,3 +93,9 @@
 ! (assertEqual (OS.takeN 4 (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS)))))) (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 NilOS)))))
 ! (assertEqual (OS.takeN 5 (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS)))))) (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS))))))
 ! (assertEqual (OS.takeN 6 (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS)))))) (ConsOS 4 (ConsOS 3 (ConsOS 2 (ConsOS 1 (ConsOS 0 NilOS))))))
+
+;; Test cases -- Remove by index
+! (assertEqual (OS.removeByIdx (ConsOS 10 (ConsOS 20 NilOS)) 0) (ConsOS 20 NilOS))        
+! (assertEqual (OS.removeByIdx (ConsOS a (ConsOS b (ConsOS c NilOS))) 1) (ConsOS a (ConsOS c NilOS)))
+! (assertEqual (OS.removeByIdx (ConsOS 5 (ConsOS 6 (ConsOS 7 NilOS))) 2) (ConsOS 5 (ConsOS 6 NilOS)))
+! (assertEqual (OS.removeByIdx (ConsOS 1 (ConsOS 2 NilOS)) 5) (Error NilOS "empty set/index out of range"))        


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implementation of `resizeMetapop` function used to maintain an exemplars count that is not either too big for processing or too small for optimal exploration. The `metapopulation` is implemented as ordered set of scored trees, aka `Exemplars`.

## Motivation and Context
The idea of resizing the metapopulation is intended so that the pop doesn't become too big for the available RAM size. On the other end of the spectrum, we want to be able to keep enough exemplars to give us ample room for exploring new solutions from all kinds of parent expressions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
