### PR TITLE
Workflow name and branch lists update

### DIFF
--- a/.github/workflows/MeTTa-CI.yml
+++ b/.github/workflows/MeTTa-CI.yml
@@ -2,12 +2,18 @@ name: MeTTaLog CI
 
 on:
   push:
-    branches: [ref/mettalog]
+    branches:
+      - main
+      - dev
+      - ref/*
   pull_request:
-    branches: [ref/mettalog]
+    branches:
+      - main
+      - dev
+      - ref/*
 
 jobs:
-  mettalog-test:
+  setup-and-test:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Changed the workflow job name to be similar to the github merge requirement setting and also included more branches as `main`, `dev` and `ref/*` instead of a static `ref/mettalog`.