### PR TITLE
Implement LRU Cache

### DIFF
--- a/feature-selection/incremental.metta
+++ b/feature-selection/incremental.metta
@@ -44,18 +44,18 @@
 ;;   $resultSet (OS Number) → Accumulator for relevant indices
 ;; Returns: (OS Number) → OrderedSet of relevant feature indices
 (: filterRelevantCombinations (-> ITable (OS Expression) Number (OS Number) (OS Number)))
-(= (filterRelevantCombinations $itable $combinations $threshold $resultSet)
-   (unify $combinations NilOS
-     $resultSet
-     (unify $combinations (ConsOS $combo $rest)
-       (chain (expressionToOS $combo NilOS) $comboOS
-         (chain (calculateMutualInformation $itable $comboOS) $mutualInfo
-           (if (> $mutualInfo $threshold)
-             (chain (OS.union $resultSet $comboOS) $newResultSet
-               (filterRelevantCombinations $itable $rest $threshold $newResultSet))
-             (filterRelevantCombinations $itable $rest $threshold $resultSet))))
-       ;;  fallback
-       $resultSet)
+(= (filterRelevantCombinations $itable NilOS $threshold $resultSet)
+ $resultSet)
+
+(= (filterRelevantCombinations $itable (ConsOS $combo $rest) $threshold $resultSet)
+   (chain (expressionToOS $combo NilOS) $comboOS
+     (chain (calculateMutualInformation $itable $comboOS) $mutualInfo
+       (if (> $mutualInfo $threshold)
+           (chain (OS.union $resultSet $comboOS) $newResultSet
+             (filterRelevantCombinations $itable $rest $threshold $newResultSet))
+           (filterRelevantCombinations $itable $rest $threshold $resultSet)
+        )
+      )
     )
 )
 
@@ -68,19 +68,18 @@
 ;;   $currentScore (Number) → Current best score
 ;; Returns: (List Expression) → (best-subset best-score)
 (: findBestSubset (-> ITable (OS Expression) Expression Number (List Expression)))
-(= (findBestSubset $itable $subsetCombinations $currentBest $currentScore)
-   (unify $subsetCombinations NilOS
-     (Cons $currentBest (Cons $currentScore Nil))
-     (unify $subsetCombinations (ConsOS $subset $rest)
-       (chain (expressionToOS $subset NilOS) $subsetOS
-         (chain (calculateMutualInformation $itable $subsetOS) $score
-           (if (> $score $currentScore)
-             (findBestSubset $itable $rest $subset $score)
-             (findBestSubset $itable $rest $currentBest $currentScore))))
-       ;; fallback
-       (Cons $currentBest (Cons $currentScore Nil))
+(= (findBestSubset $itable NilOS $currentBest $currentScore)
+   (Cons $currentBest (Cons $currentScore Nil)))
+
+(= (findBestSubset $itable (ConsOS $subset $rest) $currentBest $currentScore)
+   (chain (expressionToOS $subset NilOS) $subsetOS
+     (chain (calculateMutualInformation $itable $subsetOS) $score
+       (if (> $score $currentScore)
+           (findBestSubset $itable $rest $subset $score)
+           (findBestSubset $itable $rest $currentBest $currentScore)
+       )
      )
-    )
+   )
 )
 ;; Purpose: Find redundant features using subset search
 ;; Parameters:

--- a/feature-selection/incremental.metta
+++ b/feature-selection/incremental.metta
@@ -36,6 +36,10 @@
     )
 )
 
+;** Implement caching for the mutual Information
+(= (cachedMutualInformation $itable $featureIndices)
+    (lruCache DEFAULT_CACHE_SIZE ((calculateMutualInformation) ($itable $featureIndices)))
+)
 ;; Purpose: Filter relevant combinations based on MI threshold
 ;; Parameters:
 ;;   $itable (ITable) → Input table
@@ -49,7 +53,7 @@
 
 (= (filterRelevantCombinations $itable (ConsOS $combo $rest) $threshold $resultSet)
    (chain (expressionToOS $combo NilOS) $comboOS
-     (chain (calculateMutualInformation $itable $comboOS) $mutualInfo
+     (chain (cachedMutualInformation $itable $comboOS) $mutualInfo
        (if (> $mutualInfo $threshold)
            (chain (OS.union $resultSet $comboOS) $newResultSet
              (filterRelevantCombinations $itable $rest $threshold $newResultSet))
@@ -73,7 +77,7 @@
 
 (= (findBestSubset $itable (ConsOS $subset $rest) $currentBest $currentScore)
    (chain (expressionToOS $subset NilOS) $subsetOS
-     (chain (calculateMutualInformation $itable $subsetOS) $score
+     (chain (cachedMutualInformation $itable $subsetOS) $score
        (if (> $score $currentScore)
            (findBestSubset $itable $rest $subset $score)
            (findBestSubset $itable $rest $currentBest $currentScore)
@@ -102,7 +106,7 @@
                                 (chain (findBestSubset $itable $subsetCombinations () -1) $bestResult
                                     (chain (List.getByIdx $bestResult 0) $bestSubsetExpr
                                         (chain (List.getByIdx $bestResult 1) $bestScore
-                                            (chain (calculateMutualInformation $itable $indices) $fullScore
+                                            (chain (cachedMutualInformation $itable $indices) $fullScore
                                                 (if (< (- $fullScore $bestScore) $threshold)
                                                     (chain (expressionToOS $bestSubsetExpr NilOS) $bestSubset
                                                         (chain (OS.difference $indices $bestSubset NilOS) $redundant
@@ -214,7 +218,7 @@
         (let (mkITable $rows $labels) $itable
             (chain (- (List.length $labels) 1) $numFeatures
                 (chain (OS.range 0 $numFeatures NilOS) $allIndices
-                    (chain (calculateMutualInformation $itable $allIndices) $score
+                    (chain (cachedMutualInformation $itable $allIndices) $score
                         (chain (osToExpression $allIndices ()) $indicesExpr
                             ($score $indicesExpr) ;; return Indices and score
                         )
@@ -237,7 +241,7 @@
                 ) $selectedIndices
             (chain (if (== (OS.length $selectedIndices) 0)
                         0
-                        (calculateMutualInformation $itable $selectedIndices)
+                        (cachedMutualInformation $itable $selectedIndices)
                     ) $finalScore
                 (chain (osToExpression $selectedIndices ()) $indicesExpr
                     ($finalScore $indicesExpr)

--- a/feature-selection/tests/incremental-test.metta
+++ b/feature-selection/tests/incremental-test.metta
@@ -5,6 +5,7 @@
 ! (import! &self metta-moses:utilities:ordered-set)
 ! (import! &self metta-moses:feature-selection:feature-selection-helpers)
 ! (import! &self metta-moses:feature-selection:incremental)
+! (import! &self metta-moses:utilities:lru-cache)
 
 ! (bind! andTable 
    (mkITable

--- a/utilities/lru-cache.metta
+++ b/utilities/lru-cache.metta
@@ -1,0 +1,190 @@
+;; LRU CACHE IMPLEMENTATION
+;; A Least Recently Used (LRU) cache implementation in MeTTa that automatically
+;; evicts the least recently accessed items when the cache reaches capacity.
+
+
+;; Space to store cache entries and access times
+!(bind! &cache (new-space))
+; (: &cache hyperon::space::DynSpace) ;; this is how you define types for space
+
+;; State variables for cache management
+!(bind! cacheSize (new-state 0))         ;; Current number of cached items
+!(bind! maxCacheSize (new-state 10))     ;; Maximum cache capacity
+!(bind! accessCounter (new-state 0))     ;; counter for timestamps
+; (: cacheSize StateMonad) ;; this is how you define types for states 
+
+!(bind! DEFAULT_CACHE_SIZE 60)
+
+;; Function: cacheExists
+;; Purpose: Check if a function call with given arguments exists in cache
+(: cacheExists (-> Symbol Any Bool))
+(= (cacheExists $functionName $argument)
+    (let* 
+        (
+            ; (() (println! (DEBUG Inside cacheExists $functionName $argument)))
+            ($queryResult (collapse (match &cache (cacheEntry $functionName $argument $result $timestamp) $result)))
+            ; (() (println! (DEBUG query Result: $queryResult)))
+        )
+        (not (== $queryResult ()))
+    )
+)
+
+;; Function: nextTimestamp  
+;; Purpose: Generate next sequential timestamp for cache ordering
+(: nextTimestamp (-> Number))
+(= (nextTimestamp)
+   (let* 
+       (
+           ($currentCounter (get-state accessCounter))
+        ;    (() (println! (DEBUG function currentCounter: $currentCounter (get-state accessCounter))))
+           ($nextCounter (+ $currentCounter 1))
+           ($updatedState (change-state! accessCounter $nextCounter))
+        ;    (() (println! (DEBUG updated state $updatedState)))
+       )
+       $nextCounter
+    )
+)
+
+;; Function: getCached
+;; Purpose: Retrieve cached result and update its access time (move to front)
+(: getCached (-> Symbol Any Any))
+(= (getCached $functionName $argument)
+    (let* 
+        (
+            ;; Retrieve cached result and its timestamp
+            ($retrievedCache (collapse (match &cache (cacheEntry $functionName $argument $result $timestamp) ($result $timestamp))))
+            ; (() (println! (DEBUG $argument cached Result: $retrievedCache)))
+        )
+        (if (== $retrievedCache ())
+            (Error $functionName "Not Found")
+            (let* 
+                (
+                    ((($cachedResult $oldTimeStamp)) $retrievedCache)
+                    ($newTimeStamp (nextTimestamp))
+                    ; (() (println! (DEBUG New Time Stamp: $newTimeStamp)))
+                    ;; Remove old cache entries
+                    (() (remove-atom &cache (cacheEntry $functionName $argument $cachedResult $oldTimeStamp)))
+                    (() (remove-atom &cache (accessTime $functionName $argument $oldTimeStamp)))
+                    ;; Add updated entries with new timestamp
+                    (() (add-atom &cache (cacheEntry $functionName $argument $cachedResult $newTimeStamp)))
+                    (() (add-atom &cache (accessTime $functionName $argument $newTimeStamp)))
+                )
+                $cachedResult
+            )
+        )
+    )
+)
+
+;; Function: byLastAtom
+;; Purpose: Comparison function for sorting access times (ascending order)
+(: byLastAtom (-> Expression Expression Bool))
+(= (byLastAtom $x $y) 
+    (let* (
+        ($xlastEl (- (size-atom $x) 1))
+        ($ylastEl (- (size-atom $y) 1))
+        ($xLast (index-atom $x $xlastEl))
+        ($yLast (index-atom $y $ylastEl))
+        )
+      (< $xLast $yLast)
+    )
+)
+
+;; Function: removeLeastRecentlyUsed
+;; Purpose: Evict the least recently used cache entry to make room for new entry
+(: removeLeastRecentlyUsed (-> Symbol Any Any Any))
+(= (removeLeastRecentlyUsed $funcs $arguments $results) 
+    (let* 
+        (
+            ;; Get all access time entries
+            ($allAccessTimes (collapse (match &cache (accessTime $fn $args $timestamp) (accessEntry $fn $args $timestamp))))
+        )
+        (if (== $allAccessTimes ())
+            (Error "Cache Empty")
+            (let*
+                (
+                    ; (() (println! (DEBUG all access Times: $allAccessTimes)))
+                    ;; Sort by timestamp to find least recently used
+                    ($sortedAccess (selectionSort $allAccessTimes (size-atom $allAccessTimes) byLastAtom))
+                    ; (() (println! (DEBUG all Sorted Access: $sortedAccess)))
+                    ;; Extract least recently used entry details
+                    ((accessEntry $functionName $args $timeStamp) (index-atom $sortedAccess 0))
+                    ;; Get the cached result for removal
+                    ($result (match &cache (cacheEntry $functionName $args $answer $timeStamp) $answer))
+                    ;; Remove both cache entry and access time entry
+                    (() (remove-atom &cache (cacheEntry $functionName $args $result $timeStamp)))
+                    (() (remove-atom &cache (accessTime $functionName $args $timeStamp)))
+                    ;; Update cache size
+                    ($updatedState (change-state! cacheSize (- (get-state cacheSize) 1)))
+                    ; (() (println! (DEBUG all Updated state in remove LRU $updatedState)))
+                )
+                ;; Add the new entry
+                (cachePut $funcs $arguments $results)
+            )
+        )
+    )
+)
+
+;; Function: cachePut
+;; Purpose: Add a new entry to the cache, handling capacity limits
+(: cachePut (-> Symbol Any Any Any))
+(= (cachePut $functionName $argument $result)
+    (let* 
+        (
+            ($timestamp (nextTimestamp))
+            ; (() (println! (DEBUG function timestamp: $timestamp)))
+            ($currentSize (get-state cacheSize))
+            ($maxSize (get-state maxCacheSize))
+            ; (() (println! (DEBUG function current size: $currentSize maxSize $maxSize $functionName $argument $result)))
+        )
+        (if (>= $currentSize $maxSize)
+            ;; Cache is full, evict least recently used
+            (removeLeastRecentlyUsed $functionName $argument $result)
+            ;; Cache has space, add directly
+            (let* 
+                (
+                    ;; Add cache entry and access time
+                    (() (add-atom &cache (cacheEntry $functionName $argument $result $timestamp)))
+                    (() (add-atom &cache (accessTime $functionName $argument $timestamp)))
+                    ;; Update cache size
+                    ($updatedCache (change-state! cacheSize (+ $currentSize 1)))
+                    ; (() (println! (DEBUG Updated $updatedCache)))
+                )  
+                $result
+            )
+        )
+    )
+)
+
+;; Function: lruCache
+;; Purpose: Main LRU cache interface - checks cache first, computes if needed
+(: lruCache (-> Number Expression Any))
+(= (lruCache $maxSize $functionCall) 
+    (let* 
+        (
+            ;; Set cache size for this operation
+            ($setup (change-state! maxCacheSize $maxSize))
+            ; (() (println! (DEBUG changed max size: $setup)))
+            ;; Parse function call structure
+            (($funcExpr $argExpr) (decons-atom $functionCall))
+            ($functionName (car-atom $funcExpr))
+            ($argument (car-atom $argExpr))
+            ; (() (println! (DEBUG function with argument: $functionName $argument)))
+        )
+        ;; Check cache first
+        (if (cacheExists $functionName $argument)
+            (getCached $functionName $argument)
+            ;; Cache miss - compute and cache result
+            (let* 
+                (
+                    ; (() (println! (DEBUG Inside Computation ($functionName $argument))))
+                    ;; Execute the function call
+                    ($computedResult (eval (cons-atom $functionName $argument)))
+                    ; (() (println! (DEBUG Computed result: $computedResult $functionName $argument)))
+                    ;; Cache the result
+                    ($cachedResult (cachePut $functionName $argument $computedResult))
+                )
+                $cachedResult
+            )
+        )
+    )
+)

--- a/utilities/ordered-set.metta
+++ b/utilities/ordered-set.metta
@@ -142,15 +142,12 @@
 ;; Returns: (OS Number) → Union of both sets
 ;; Example: (OS.union (ConsOS 0 (ConsOS 1 NilOS)) (ConsOS 2 NilOS)) → (ConsOS 0 (ConsOS 1 (ConsOS 2 NilOS)))
 (: OS.union (-> (OS Number) (OS Number) (OS Number)))
-(= (OS.union $set1 $set2)
-   (unify $set1 NilOS
-     $set2
-     (unify $set1 (ConsOS $head $tail)
-       (chain (OS.insert genericCompare $head $set2) $newSet2
-         (OS.union $tail $newSet2))
-       $set2
-     )
-    )
+(: OS.union (-> (OS Number) (OS Number) (OS Number)))
+(= (OS.union NilOS $set2) $set2)
+(= (OS.union (ConsOS $head $tail) $set2)
+   (chain (OS.insert genericCompare $head $set2) $newSet2
+     (OS.union $tail $newSet2)
+   )
 )
 
 ;; Purpose: Difference of two OrderedSets (set1 - set2)
@@ -161,16 +158,13 @@
 ;; Returns: (OS Number) → Elements in set1 but not in set2
 ;; Example: (OS.difference (ConsOS 0 (ConsOS 1 NilOS)) (ConsOS 1 NilOS) NilOS) → (ConsOS 0 NilOS)
 (: OS.difference (-> (OS Number) (OS Number) (OS Number) (OS Number)))
-(= (OS.difference $set1 $set2 $result)
-   (unify $set1 NilOS
-     $result
-     (unify $set1 (ConsOS $head $tail)
-       (if (OS.contains $set2 $head)
-         (OS.difference $tail $set2 $result)
-         (chain (OS.insert genericCompare $head $result) $newResult
-           (OS.difference $tail $set2 $newResult)))
-       $result
-     )
+(= (OS.difference NilOS $set2 $result) $result)
+(= (OS.difference (ConsOS $head $tail) $set2 $result)
+   (if (OS.contains $set2 $head)
+       (OS.difference $tail $set2 $result)
+       (chain (OS.insert genericCompare $head $result) $newResult
+         (OS.difference $tail $set2 $newResult)
+       )
     )
 )
 
@@ -182,14 +176,10 @@
 ;; Returns: (Expression) → Expression with OS elements
 ;; Example: (osToExpression (ConsOS 0 (ConsOS 1 (ConsOS 2 NilOS))) ()) → (0 1 2)
 (: osToExpression (-> (OS $a) Expression Expression))
-(= (osToExpression $os $acc)
-   (unify $os NilOS
-     $acc
-     (unify $os (ConsOS $head $tail)
-       (let $rest (osToExpression $tail $acc)
-         (cons-atom $head $rest))
-       $acc
-     )
+(= (osToExpression NilOS $acc) $acc)
+(= (osToExpression (ConsOS $head $tail) $acc)
+   (let $rest (osToExpression $tail $acc)
+     (cons-atom $head $rest)
    )
 )
 

--- a/utilities/tests/lru-cache-test.metta
+++ b/utilities/tests/lru-cache-test.metta
@@ -1,0 +1,99 @@
+!(register-module! ../../../metta-moses)
+!(import! &self metta-moses:utilities:general-helpers)
+!(import! &self metta-moses:feature-selection:feature-selection-helpers)
+!(import! &self metta-moses:utilities:list-methods)
+!(import! &self metta-moses:utilities:lru-cache)
+
+(: factorial (-> Number Number))
+(= (factorial $x)
+   (if (> $x 0)
+       (* $x (factorial (- $x 1)))
+       1))
+
+(: multiply (-> Number Number Number Number))
+(= (multiply $a $b $c) (* (* $a $b) $c))
+
+(: cachedFactorial (-> Number Number))
+(= (cachedFactorial $n)
+   (lruCache DEFAULT_CACHE_SIZE ((factorial) ($n))))
+
+(: cachedMultiply (-> Number Number Number Number))
+(= (cachedMultiply $a $b $c)
+   (lruCache 3 ((multiply) ($a $b $c))))
+
+(: cachedMutualInformation (-> Expression Expression Number))
+(= (cachedMutualInformation $inputColumn $outputColumn)
+    (lruCache 3 ((mutualInformation) ($inputColumn $outputColumn))))
+
+;; ---- Factorial Tests ----
+!(assertEqual (cachedFactorial 5) 120)       ;; first call (cache miss, compute and store)
+!(assertEqual (cacheExists factorial (5)) True)
+!(assertEqual (getCached factorial (5)) 120) ;; confirm value stored in cache
+!(assertEqual (cachedFactorial 5) 120)       ;; second call (cache hit)
+!(assertEqual (cachedFactorial 4) 24)
+!(assertEqual (cachedFactorial 3) 6)
+
+!(assertEqual (cacheExists factorial (3)) True)
+!(assertEqual (getCached factorial (3)) 6)
+
+;; ---- Multiply Tests ----
+!(assertEqual (cachedMultiply 2 3 4) 24)     ;; compute and store
+!(assertEqual (cacheExists multiply (2 3 4)) True)
+!(assertEqual (getCached multiply (2 3 4)) 24)
+!(assertEqual (cachedMultiply 2 3 4) 24)     ;; cache hit
+!(assertEqual (cachedMultiply 1 2 3) 6)
+!(assertEqual (cachedMultiply 5 2 1) 10)
+
+!(assertEqual (cacheExists multiply (5 2 1)) True)
+!(assertEqual (getCached multiply (5 2 1)) 10)
+
+;; ---- Mutual Information Tests ----
+!(assertEqual 
+   (cachedMutualInformation 
+      (Cons A (Cons B (Cons C Nil))) 
+      (Cons X (Cons Y (Cons Z Nil)))) 
+   1.585)
+
+;; Multiple calls to ensure cache hits
+!(assertEqual 
+   (cachedMutualInformation 
+      (Cons A (Cons B (Cons C Nil))) 
+      (Cons X (Cons Y (Cons Z Nil)))) 
+   1.585) ;; cache hit
+!(assertEqual 
+   (cachedMutualInformation 
+      (Cons A (Cons B (Cons C Nil))) 
+      (Cons X (Cons Y (Cons Z Nil)))) 
+   1.585) ;; another cache hit
+
+;; Verify number of cached elements across functions
+!(assertEqual 
+   (let $cachedElements (collapse (get-atoms &cache)) 
+        (size-atom $cachedElements)) 
+   6)
+
+;; ---- Manual Cache Operations ----
+!(assertEqual (cachePut computationallyExpensiveFunction (arg1 arg2) someResult) someResult)
+!(assertEqual (cacheExists computationallyExpensiveFunction (arg1 arg2)) True)
+!(assertEqual (getCached computationallyExpensiveFunction (arg1 arg2)) someResult)
+
+;; Remove least recently used (LRU) entry
+!(assertEqual (removeLeastRecentlyUsed factorial (12) 479001600) 479001600)
+
+;; After LRU eviction, confirm that "multiply (1 2 3)" entry is removed
+!(assertEqual (cacheExists multiply (1 2 3)) False)
+!(assertEqual (getCached multiply (1 2 3)) (Error multiply "Not Found"))
+
+;; But factorial(12) should still exist
+!(assertEqual (getCached factorial (12)) 479001600)
+
+;; Confirm cache size remains stable after eviction
+!(assertEqual 
+   (let $cachedElements (collapse (get-atoms &cache)) 
+        (size-atom $cachedElements)) 
+   6)
+
+
+;; Cache overwrite test: same key, updated value
+!(assertEqual (cachePut factorial (3) 999) 999)
+!(assertEqual (getCached factorial (3)) 999) ;; overwritten


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces **LRU caching** into the incremental feature selection workflow and refactors several functions to use **pattern matching overloads** instead of `unify`.

### Key changes:
- Implemented `lruCache` and applied it to incremental selection
- Replaced `unify`-based branching with **function overloading** for:
- Added **structured tests** for caching behavior, eviction, overwrites, and edge cases.

## Motivation and Context
- **Performance:**  
  Previously, incremental feature selection took **~2 minutes 7 seconds on average**.  
<img width="191" height="76" alt="image" src="https://github.com/user-attachments/assets/f50c47c9-d7bc-4cda-8483-c85a430a3906" />
<img width="183" height="60" alt="image" src="https://github.com/user-attachments/assets/2db2014e-8499-4715-923e-ba3f60ee49cd" />

  With caching, the runtime has been reduced to **~33.7 seconds on average**.
- **Readability & Maintainability:**  
  Using pattern matching instead of `unify` makes code more idiomatic, cleaner, and easier to reason about.

## How Has This Been Tested?
- Added unit tests for:
  - `cachedFactorial` (hits, misses, eviction, overwrite)
  - `cachedMultiply` (hits, misses, edge cases with zero)
  - `cachedMutualInformation` (cache behavior across multiple calls)
- Verified **LRU eviction** and **cache size consistency**.
- Confirmed feature selection workflow runs significantly faster with caching.
## Types of changes
- [x] Performance improvement (non-breaking change that improves efficiency)
- [x] Refactor (cleaner implementation using pattern matching instead of unify)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Performance benchmarks recorded.
