### PR TITLE
Fix score Cache duplicates  (issue #334) and refactor function  (isPossible)

### DIFF
--- a/moses/neighborhood-sampling.metta
+++ b/moses/neighborhood-sampling.metta
@@ -221,10 +221,8 @@
 (= (isPossibleSize $sampleSize $dist $m (mkInst $inst)) 
     
             (let* (
-                ($list (cdr-atom $inst))
                 ; (() (println! (Inside isPossibleSize: $inst $dist $sampleSize)))
-                ($centralInst (car-atom $list))
-                ($instLen (List.length $centralInst))
+                ($instLen (List.length $inst))
                 ;  (() (println! (Instance Length: $instLen)))
                 ($n (factorial $instLen))
                 ($r (factorial (- $instLen $dist)))

--- a/moses/neighborhood-sampling.metta
+++ b/moses/neighborhood-sampling.metta
@@ -217,8 +217,8 @@
 ;; Returns: true if total neighbors ≥ $sampleSize, else false
 ;; Formula: n! / ((n - d)! * d!) * (m-1)^d  ( where n = instance length, d = hamming distance, m = knob multiplicity)
 
-(: isPossibleSize (-> Instance Number Number Bool))
-(= (isPossibleSize $sampleSize $dist $inst) 
+(: isPossibleSize (-> Number Number Number Instance  Bool))
+(= (isPossibleSize $sampleSize $dist $m (mkInst $inst)) 
     
             (let* (
                 ($list (cdr-atom $inst))
@@ -229,9 +229,9 @@
                 ($n (factorial $instLen))
                 ($r (factorial (- $instLen $dist)))
                 ($d (factorial $dist))
-                ($m (pow-math 2 $dist)) ; assuming knob multiplicty is 3, so m-1 = 1, hence m = 2 that is why (pow-math 2 $dist)
+                ($k (pow-math (- $m 1) $dist)) ; assuming knob multiplicty is 3, so m-1 = 1, hence m = 2 that is why (pow-math 2 $dist)
                 ($maxNeighbors (/ $n (* $r $d)))
-                ($totalNeighbors (* $maxNeighbors $m))
+                ($totalNeighbors (* $maxNeighbors $k))
               ) 
                 (>= $totalNeighbors $sampleSize)
                 ; $totalNeighbors

--- a/moses/neighborhood-sampling.metta
+++ b/moses/neighborhood-sampling.metta
@@ -160,7 +160,7 @@
 
 (: sampleFromNeighborhood (-> Number Number KnobMap Instance (List Instance)))
 (= (sampleFromNeighborhood $sampleSize $dist $kbMp $inst)
-      ( if (== (isPossibleSize $sampleSize $dist $inst) False)
+      ( if (== (isPossibleSize $sampleSize $dist 3 $inst) False)
           (Error ("Cannot generate " $sampleSize " instances at distance " $dist " from " $inst) (Requested sample size too large))
           (selectUnique () $sampleSize $dist $kbMp $inst)
       )

--- a/moses/tests/neighborhood-sampling-test.metta
+++ b/moses/tests/neighborhood-sampling-test.metta
@@ -219,5 +219,5 @@ Nil)
 
 ;testcase for isPossibleSize function
 ; Formula: n! / ((n - d)! * d!) * (m-1)^d  (n = instance length, d = distance, m = knob multiplicity)
- !(assertEqual (isPossibleSize 13 2 (mkInst (Cons 1 (Cons 2 (Cons 0 Nil))))) False)
- !(assertEqual (isPossibleSize 10 2 (mkInst (Cons 1 (Cons 2 (Cons 0 Nil))))) True)
+ !(assertEqual (isPossibleSize 13 2 3 (mkInst (Cons 1 (Cons 2 (Cons 0 Nil))))) False)
+ !(assertEqual (isPossibleSize 10 2 3 (mkInst (Cons 1 (Cons 2 (Cons 0 Nil))))) True)

--- a/scoring/cscore.metta
+++ b/scoring/cscore.metta
@@ -6,7 +6,7 @@
 (= (getCscore $itable $tree $complexityRatio $scoreSpace)
     (unify $scoreSpace 
             ($tree $score) 
-            (trace! "USED from cache XXXXXXXXXXXXXXXXXXXXXXXXXXX " $score)
+            (trace! "USED from cache XXXXXXXXXXXXXXXXXXXXXXXXXXX " (let $duplicateScoreList (collapse (match $scoreSpace ($tree $score) $score)) (car-atom $duplicateScoreList)))
             (chain (scoreTree $itable $tree) $bs 
                 (if-error $bs ;; return worst possible composite score
                 (worstCscore)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixes and refactors for scoreCache and function signatures

## Description
- Fixed duplicate tree scores in `scoreCache` to use only the first score of a tree (Fixes #334).  
- Refactored function "isPossible" signatures and updated parameter `m` to allow dynamic usage (e.g., feature selection variant).  
- Removed unnecessary function calls by changing parameter format.  
- Updated function call formatting to align with the refactored parameter structure.

## Motivation and Context
These changes are required to:  
- Ensure deterministic behavior in score caching.  
- Make functions more flexible for different use cases (feature selection vs. optimization).  
- Simplify function usage by eliminating unnecessary calls.  
- Maintain consistent function signatures and calls across the codebase.

## How Has This Been Tested?
- Verified `scoreCache` behavior with sample tree data.  
- Checked function outputs with different `m` values for both standard and feature selection scenarios.  
- Ran unit tests where applicable; no errors observed.  
- Inspected code to ensure no unnecessary calls remain after refactoring.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)  
- [x] Refactor (code improvements without changing functionality)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.  
- [x] I have added tests to cover my changes where needed.  
- [x] All new and existing tests passed.  
