### PR TITLE
refactor: clean up EDA/univariate helpers, remove noisy prints, consolidate logic via higher-order functions, standardize camelCase

### DIFF
--- a/optimization/eda/eda-parameters.metta
+++ b/optimization/eda/eda-parameters.metta
@@ -12,6 +12,12 @@
 ;;
 ;; Data Structures:
 ;; - EDAParameters: mkEDAParameters (selection tournamentSize selectionRatio replacementRatio modelComplexity)
+;;
+;; Parameters:
+;; - selection: Tournament size (integer, default: 2)
+;; - selectionRatio: Fraction of population to select for learning (float, default: 1.0)
+;; - replacementRatio: Fraction of population to replace each generation (float, default: 0.5)
+;; - modelComplexity: Model complexity control (float, default: 1.0, unused in univariate)
 
 ;; ================================================================================
 ;; Type Definitions
@@ -43,4 +49,4 @@
 (= (getModelComplexity (mkEDAParameters $selection $selectionRatio $replacementRatio $modelComplexity)) $modelComplexity)
 
 ;; Default EDA parameters
-(= (default-eda-parameters) (mkEDAParameters 2 1.0 0.5 1.0))
+(= (defaultEdaParameters) (mkEDAParameters 2 1.0 0.5 1.0))

--- a/optimization/eda/eda.metta
+++ b/optimization/eda/eda.metta
@@ -100,16 +100,16 @@
 ;; (tournament-selection $tournamentSize $deme $nSelect)
 ;;
 ;; ;; Learn probability model
-;; (learn-probability-model $deme $selectedInstances)
+;; (learnProbabilityModel $deme $selectedInstances)
 ;;
 ;; ;; Sample new individuals
 ;; (sample-from-model $probModel $deme $nGenerate)
 ;;
 ;; ;; Replace worst individuals
-;; (replace-the-worst $newInstances $deme)
+;; (replaceTheWorst $newInstances $deme)
 ;;
 ;; ;; Check termination
-;; (terminate-if-gte-or-no-improv $threshold $maxGens $deme)
+;; (terminateIfGteOrNoImprovSimple $threshold $maxGens $deme)
 ;; ```
 
 ;; ================================================================================

--- a/optimization/eda/initialization.metta
+++ b/optimization/eda/initialization.metta
@@ -21,67 +21,49 @@
 ;; ================================================================================
 
 ;; Sample uniform instance for initialization
-; (: sample-uniform-instance (-> Representation Instance))
-(= (sample-uniform-instance $rep)
+; (: sampleUniformInstance (-> Representation Instance))
+(= (sampleUniformInstance $rep)
   (let* (
-        ($kv (sample-uniform-knob-values $rep))
+        ($kv (sampleUniformKnobValues $rep))
       )
-      (create-instance $rep $kv)))
+      (createInstance $rep $kv)))
 
-; (: sample-uniform-knob-values (-> Representation (Map KnobId KnobValue)))
-(= (sample-uniform-knob-values $rep)
+; (: sampleUniformKnobValues (-> Representation (Map NodeId KnobValue)))
+(= (sampleUniformKnobValues $rep)
   (let* (
-        ($pairs (get-knob-ids-and-specs $rep))
+        ($pairs (getKnobIdsAndSpecs $rep))
       )
-      (sample-uniform-kv-acc $pairs NilMap)))
+      (sampleUniformKvAcc $pairs NilMap)))
 
-; (: get-knob-ids-and-specs (-> Representation (List (Pair KnobId (DiscSpec $knob)))))
-(= (get-knob-ids-and-specs (mkRep (mkKbMap (mkDscKbMp $discKbMap) (mkDscMp $discMap)) $tree))
+; (: getKnobIdsAndSpecs (-> Representation (List (Pair NodeId (DiscSpec $knob)))))
+(= (getKnobIdsAndSpecs (mkRep (mkKbMap (mkDscKbMp $discKbMap) (mkDscMp $discMap)) $tree))
   (List.zip (Map.keys $discKbMap) (MultiMap.values $discMap)))
 
-; (: sample-uniform-kv-acc (-> (List (Pair KnobId (DiscSpec $knob))) (Map KnobId KnobValue) (Map KnobId KnobValue)))
-(= (sample-uniform-kv-acc Nil $acc) 
+;; Helper: compute a safe random integer in [0, m-1]
+; (: randomIndexBelow (-> Number Number))
+(= (randomIndexBelow $m)
   (let* (
-        (() (println! (sample-uniform-kv-acc: Nil case)))
-      )
-      $acc))
-(= (sample-uniform-kv-acc (Cons ($kid (mkLSK (mkDiscKnob (mkKnob $nodeId) (mkMultip $m) $d1 $d2 $rest))) $restPairs) $acc)
-  (let* (
-        (() (println! (sample-uniform-kv-acc: LSK pattern matched)))
-        (() (println! (sample-uniform-kv-acc: got kid $kid)))
-        (() (println! (sample-uniform-kv-acc: got nodeId $nodeId)))
-        (() (println! (sample-uniform-kv-acc: got m $m)))
-        (() (println! (sample-uniform-kv-acc: starting)))
         ($rf (randomFloat))
-        (() (println! (sample-uniform-kv-acc: got rf $rf)))
         ($val (int (* $rf $m)))
-        (() (println! (sample-uniform-kv-acc: got val $val)))
-        ($safe (if (== $val $m) (- $m 1) $val))
-        (() (println! (sample-uniform-kv-acc: got safe $safe)))
-        ($knobValue (mkKnobValue $safe))
-        (() (println! (sample-uniform-kv-acc: got knobValue $knobValue)))
-        ($acc2 (Map.insert ($kid $knobValue) $acc == nodeId<))
-        (() (println! (sample-uniform-kv-acc: got acc2 $acc2)))
       )
-      (sample-uniform-kv-acc $restPairs $acc2)))
-(= (sample-uniform-kv-acc (Cons ($kid (mkDiscSpec $m)) $rest) $acc)
+      (if (== $val $m) (- $m 1) $val)))
+
+;; Helper: extract multiplicity from spec variants
+; (: getMultiplicity (-> (DiscSpec $knob) Number))
+(= (getMultiplicity (mkDiscSpec $m)) $m)
+; (: getMultiplicity (-> (LSK $a) Number))
+(= (getMultiplicity (mkLSK (mkDiscKnob (mkKnob $nodeId) (mkMultip $m) $d1 $d2 $rest))) $m)
+
+; (: sampleUniformKvAcc (-> (List (Pair NodeId (DiscSpec $knob))) (Map NodeId KnobValue) (Map NodeId KnobValue)))
+(= (sampleUniformKvAcc Nil $acc) $acc)
+(= (sampleUniformKvAcc (Cons ($kid $spec) $rest) $acc)
   (let* (
-        (() (println! (sample-uniform-kv-acc: DiscSpec pattern matched)))
-        (() (println! (sample-uniform-kv-acc: got kid $kid)))
-        (() (println! (sample-uniform-kv-acc: got m $m)))
-        (() (println! (sample-uniform-kv-acc: starting)))
-        ($rf (randomFloat))
-        (() (println! (sample-uniform-kv-acc: got rf $rf)))
-        ($val (int (* $rf $m)))
-        (() (println! (sample-uniform-kv-acc: got val $val)))
-        ($safe (if (== $val $m) (- $m 1) $val))
-        (() (println! (sample-uniform-kv-acc: got safe $safe)))
+        ($m (getMultiplicity $spec))
+        ($safe (randomIndexBelow $m))
         ($knobValue (mkKnobValue $safe))
-        (() (println! (sample-uniform-kv-acc: got knobValue $knobValue)))
         ($acc2 (Map.insert ($kid $knobValue) $acc == nodeId<))
-        (() (println! (sample-uniform-kv-acc: got acc2 $acc2)))
       )
-      (sample-uniform-kv-acc $rest $acc2)))
+      (sampleUniformKvAcc $rest $acc2)))
 
 ;; ================================================================================
 ;; Future Initialization Policies

--- a/optimization/eda/probability-learning.metta
+++ b/optimization/eda/probability-learning.metta
@@ -1,21 +1,38 @@
 ;; ================================================================================
-;; Probability Learning Policy
+;; Probability Learning Policy for EDA (Estimation of Distribution Algorithm)
 ;; ================================================================================
 ;;
-;; This file implements the probability learning policy for EDA.
-;; Equivalent to the model building logic in local_structure.h/cc in the C++ implementation.
+;; This file implements the probability learning policy for EDA, which is equivalent
+;; to the model building logic in local_structure.h/cc in the C++ implementation.
 ;;
-;; Key Components:
-;; - Learn probability distributions from selected instances
-;; - Count knob value occurrences
-;; - Compute probabilities with Laplace smoothing
-;; - Normalize probability distributions
+;; MATHEMATICAL FOUNDATION:
+;; The probability learning process follows these steps:
 ;;
-;; Data Structures:
-;; - KnobProbabilityModel: mkKnobProbabilityModel (Map NodeId (Map KnobValue Number))
-;; - KnobValue: mkKnobValue Number
-;; - KnobId: NodeId
-
+;; 1. COUNTING PHASE:
+;;    - Count occurrences of each knob value in selected instances
+;;    - For each knob k and value v: count[k][v] = number of times v appears for knob k
+;;
+;; 2. LAPLACE SMOOTHING PHASE:
+;;    - Apply Laplace smoothing to prevent zero probabilities
+;;    - Formula: smoothed_count[k][v] = count[k][v] + α
+;;    - Where α = 1 (smoothing parameter)
+;;
+;; 3. NORMALIZATION PHASE:
+;;    - Convert counts to probabilities by normalization
+;;    - Formula: P(k,v) = smoothed_count[k][v] / Σ(smoothed_count[k][v'] for all v')
+;;    - This ensures Σ P(k,v) = 1 for each knob k
+;;
+;; PROBABILITY MODEL STRUCTURE:
+;; - KnobProbabilityModel: Map<NodeId, Map<KnobValue, Probability>>
+;; - Each knob (NodeId) has a probability distribution over its possible values
+;; - Probabilities sum to 1.0 for each knob
+;;
+;; EXAMPLE CALCULATION:
+;; Given knob values: [0,1,0,1,1] for knob k
+;; - Raw counts: count[k][0] = 2, count[k][1] = 3
+;; - Laplace smoothing: smoothed[k][0] = 3, smoothed[k][1] = 4
+;; - Normalization: P(k,0) = 3/7, P(k,1) = 4/7
+;;
 ;; ================================================================================
 ;; Type Definitions
 ;; ================================================================================
@@ -27,76 +44,83 @@
 (: mkKnobProbabilityModel (-> (Map NodeId (Map KnobValue Number)) KnobProbabilityModel))
 
 ;; ================================================================================
-;; Probability Learning Policy
+;; Main Probability Learning Functions
 ;; ================================================================================
 
 ;; Learn probability distributions from selected instances
-(: learn-probability-model (-> Deme (InstanceSet $score) KnobProbabilityModel))
-(= (learn-probability-model $deme $selectedInstances)
+;; This is the main entry point for probability learning in EDA
+(: learnProbabilityModel (-> Deme (InstanceSet $score) KnobProbabilityModel))
+(= (learnProbabilityModel $deme $selectedInstances)
   (let* (
         ((mkDeme $rep (mkSInstSet $instSet) $id) $deme)
         ($discMap (getDiscMap $rep))
-        ($probModel (learn-knob-probabilities $discMap $selectedInstances))
+        ($probModel (learnKnobProbabilities $discMap $selectedInstances))
       )
       $probModel))
 
 ;; Learn probability distributions for each knob from selected instances
-; (: learn-knob-probabilities (-> (MultiMap (DiscSpec $knob)) (InstanceSet $score) KnobProbabilityModel))
-(= (learn-knob-probabilities $discMap $selectedInstances)
+;; This function orchestrates the three-phase process: count → smooth → normalize
+(: learnKnobProbabilities (-> (MultiMap (DiscSpec $knob)) (InstanceSet $score) KnobProbabilityModel))
+(= (learnKnobProbabilities $discMap $selectedInstances)
   (let* (
-        ($knobCounts (count-knob-values $discMap $selectedInstances))
-        ($probabilities (compute-probabilities $knobCounts))
+        ($knobCounts (countKnobValues $discMap $selectedInstances))
+        ($probabilities (computeProbabilities $knobCounts))
       )
       (mkKnobProbabilityModel $probabilities)))
 
+;; ================================================================================
+;; Phase 1: Counting Knob Values
+;; ================================================================================
+
 ;; Count occurrences of each knob value in selected instances
-; (: count-knob-values (-> (MultiMap (DiscSpec $knob)) (InstanceSet $score) (Map NodeId (Map KnobValue Number))))
-(= (count-knob-values $discMap $selectedInstances)
+;; Returns: Map<NodeId, Map<KnobValue, Count>>
+(: countKnobValues (-> (MultiMap (DiscSpec $knob)) (InstanceSet $score) (Map NodeId (Map KnobValue Number))))
+(= (countKnobValues $discMap $selectedInstances)
   (let* (
         ($dkmWrapped (crtDiscKnobMap (mkDscMp $discMap) (mkDscKbMp NilMap) 0))
         ((mkDscKbMp $dkm) $dkmWrapped)
-        ((mkSInstSet $lst) $selectedInstances)
+        ((mkSInstSet $instances) $selectedInstances)
       )
-      (count-knob-values-over-instances $dkm $lst NilMap)))
+      (countKnobValuesOverInstances $dkm $instances NilMap)))
 
-;; Count knob values over all instances
-; (: count-knob-values-over-instances (-> (Map (NodeId Number)) (List (ScoredInstance $score)) (Map NodeId (Map KnobValue Number)) (Map NodeId (Map KnobValue Number))))
-(= (count-knob-values-over-instances $dkm Nil $acc) $acc)
-(= (count-knob-values-over-instances $dkm (Cons $h $t) $acc)
+;; Count knob values over all instances using fold pattern
+(: countKnobValuesOverInstances (-> (Map (NodeId Number)) (List (ScoredInstance $score)) (Map NodeId (Map KnobValue Number)) (Map NodeId (Map KnobValue Number))))
+(= (countKnobValuesOverInstances $dkm Nil $acc) $acc)
+(= (countKnobValuesOverInstances $dkm (Cons $instance $rest) $acc)
   (let* (
-        ($acc2 (count-knob-values-for-instance $dkm $acc $h))
+        ($updatedAcc (countKnobValuesForInstance $dkm $acc $instance))
       )
-      (count-knob-values-over-instances $dkm $t $acc2)))
+      (countKnobValuesOverInstances $dkm $rest $updatedAcc)))
 
 ;; Count knob values for a single instance
-; (: count-knob-values-for-instance (-> (Map (NodeId Number)) (Map NodeId (Map KnobValue Number)) (ScoredInstance $score) (Map NodeId (Map KnobValue Number))))
-(= (count-knob-values-for-instance $dkm $counts (mkSInst (mkPair (mkInst $vals) $score)))
+(: countKnobValuesForInstance (-> (Map (NodeId Number)) (Map NodeId (Map KnobValue Number)) (ScoredInstance $score) (Map NodeId (Map KnobValue Number))))
+(= (countKnobValuesForInstance $dkm $counts (mkSInst (mkPair (mkInst $values) $score)))
   (let* (
         ($n (Map.length $dkm))
       )
-      (count-kv-by-idx $dkm $vals $counts 0 $n)))
+      (countKnobValuesByIndex $dkm $values $counts 0 $n)))
 
-;; Count knob values by index
-; (: count-kv-by-idx (-> (Map (NodeId Number)) (List Number) (Map NodeId (Map KnobValue Number)) Number Number (Map NodeId (Map KnobValue Number))))
-(= (count-kv-by-idx $dkm $vals $counts $i $n)
+;; Count knob values by index using iterative approach
+(: countKnobValuesByIndex (-> (Map (NodeId Number)) (List Number) (Map NodeId (Map KnobValue Number)) Number Number (Map NodeId (Map KnobValue Number))))
+(= (countKnobValuesByIndex $dkm $values $counts $i $n)
   (if (>= $i $n)
       $counts
       (let* (
             ($pair (Map.getByIdx $dkm $i))
             (($knobId $idx) $pair)
-            ($knobValueNum (List.getByIdx $vals $idx))
+            ($knobValueNum (List.getByIdx $values $idx))
             ($existingIdx (Map.find $counts $knobId))
             ($existing (if (== $existingIdx -1)
                            NilMap
                            (let ($k $v) (Map.getByIdx $counts $existingIdx) $v)))
-            ($updatedInner (increment-knob-value-count $knobValueNum $existing))
+            ($updatedInner (incrementKnobValueCount $knobValueNum $existing))
             ($updated (Map.insert ($knobId $updatedInner) $counts == nodeId<))
           )
-          (count-kv-by-idx $dkm $vals $updated (+ $i 1) $n))))
+          (countKnobValuesByIndex $dkm $values $updated (+ $i 1) $n))))
 
-;; Increment knob value count
-(: increment-knob-value-count (-> Number (Map KnobValue Number) (Map KnobValue Number)))
-(= (increment-knob-value-count $knobValueNum $existing)
+;; Increment count for a specific knob value
+(: incrementKnobValueCount (-> Number (Map KnobValue Number) (Map KnobValue Number)))
+(= (incrementKnobValueCount $knobValueNum $existing)
    (let* (
         ($knobValue (mkKnobValue $knobValueNum))
         ($existingIdx (Map.find $existing $knobValue))
@@ -107,115 +131,133 @@
       )
       (Map.insert ($knobValue $newCount) $existing knobValueEq knobValueLt)))
 
+;; ================================================================================
+;; Phase 2: Laplace Smoothing
+;; ================================================================================
+
 ;; Compute probabilities from counts with Laplace smoothing
-(: compute-probabilities (-> (Map NodeId (Map KnobValue Number)) (Map NodeId (Map KnobValue Number))))
-(= (compute-probabilities $counts)
+;; This applies the formula: smoothed_count = count + α, where α = 1
+(: computeProbabilities (-> (Map NodeId (Map KnobValue Number)) (Map NodeId (Map KnobValue Number))))
+(= (computeProbabilities $counts)
   (let* (
-        ($smoothed (laplace-smooth-outer $counts 1))
-        ($normalized (normalize-outer $smoothed))
+        ($smoothed (applyLaplaceSmoothing $counts 1))
+        ($normalized (normalizeProbabilityDistributions $smoothed))
       )
       $normalized))
 
-;; Normalize outer map (normalize each inner map)
-(: normalize-outer (-> (Map NodeId (Map KnobValue Number)) (Map NodeId (Map KnobValue Number))))
-(= (normalize-outer $m)
+;; Apply Laplace smoothing to all knob distributions
+;; Formula: smoothed[k][v] = count[k][v] + α
+(: applyLaplaceSmoothing (-> (Map NodeId (Map KnobValue Number)) Number (Map NodeId (Map KnobValue Number))))
+(= (applyLaplaceSmoothing $counts $alpha)
   (let* (
-        ($n (Map.length $m))
+        ($n (Map.length $counts))
       )
-      (normalize-outer-idx $m 0 $n NilMap)))
+      (applyLaplaceSmoothingByIndex $counts $alpha 0 $n NilMap)))
 
-(: normalize-outer-idx (-> (Map NodeId (Map KnobValue Number)) Number Number (Map NodeId (Map KnobValue Number)) (Map NodeId (Map KnobValue Number))))
-(= (normalize-outer-idx $m $i $n $acc)
+;; Apply Laplace smoothing using index-based iteration
+(: applyLaplaceSmoothingByIndex (-> (Map NodeId (Map KnobValue Number)) Number Number Number (Map NodeId (Map KnobValue Number)) (Map NodeId (Map KnobValue Number))))
+(= (applyLaplaceSmoothingByIndex $counts $alpha $i $n $acc)
   (if (>= $i $n)
       $acc
       (let* (
-            ($pair (Map.getByIdx $m $i))
-            (($kid $inner) $pair)
-            ($innerNormalized (normalize-counts $inner))
-            ($acc2 (Map.insert ($kid $innerNormalized) $acc == nodeId<))
+            ($pair (Map.getByIdx $counts $i))
+            (($knobId $innerCounts) $pair)
+            ($smoothedInner (applyLaplaceSmoothingToInner $innerCounts $alpha))
+            ($updatedAcc (Map.insert ($knobId $smoothedInner) $acc == nodeId<))
           )
-          (normalize-outer-idx $m (+ $i 1) $n $acc2))))
+          (applyLaplaceSmoothingByIndex $counts $alpha (+ $i 1) $n $updatedAcc))))
 
-;; Laplace smoothing for outer map
-(: laplace-smooth-outer (-> (Map NodeId (Map KnobValue Number)) Number (Map NodeId (Map KnobValue Number))))
-(= (laplace-smooth-outer $m $alpha)
+;; Apply Laplace smoothing to a single knob's value counts
+(: applyLaplaceSmoothingToInner (-> (Map KnobValue Number) Number (Map KnobValue Number)))
+(= (applyLaplaceSmoothingToInner $innerCounts $alpha)
   (let* (
-        ($n (Map.length $m))
+        ($len (Map.length $innerCounts))
       )
-      (laplace-smooth-outer-idx $m $alpha 0 $n NilMap)))
+      (applyLaplaceSmoothingToInnerByIndex $innerCounts $alpha 0 $len NilMap)))
 
-(: laplace-smooth-outer-idx (-> (Map NodeId (Map KnobValue Number)) Number Number Number (Map NodeId (Map KnobValue Number)) (Map NodeId (Map KnobValue Number))))
-(= (laplace-smooth-outer-idx $m $alpha $i $n $acc)
+;; Apply Laplace smoothing to inner map using index-based iteration
+(: applyLaplaceSmoothingToInnerByIndex (-> (Map KnobValue Number) Number Number Number (Map KnobValue Number) (Map KnobValue Number)))
+(= (applyLaplaceSmoothingToInnerByIndex $innerCounts $alpha $i $n $acc)
   (if (>= $i $n)
       $acc
       (let* (
-            ($pair (Map.getByIdx $m $i))
-            (($kid $inner) $pair)
-            ($innerSmoothed (laplace-smooth-inner $inner $alpha))
-            ($acc2 (Map.insert ($kid $innerSmoothed) $acc == nodeId<))
+            ($pair (Map.getByIdx $innerCounts $i))
+            (($knobValue $count) $pair)
+            ($smoothedCount (+ $count $alpha))
+            ($updatedAcc (Map.insert ($knobValue $smoothedCount) $acc knobValueEq knobValueLt))
           )
-          (laplace-smooth-outer-idx $m $alpha (+ $i 1) $n $acc2))))
+          (applyLaplaceSmoothingToInnerByIndex $innerCounts $alpha (+ $i 1) $n $updatedAcc))))
 
-;; Laplace smoothing for inner map
-(: laplace-smooth-inner (-> (Map KnobValue Number) Number (Map KnobValue Number)))
-(= (laplace-smooth-inner $inner $alpha)
+;; ================================================================================
+;; Phase 3: Probability Normalization
+;; ================================================================================
+
+;; Normalize probability distributions for all knobs
+;; This ensures that probabilities sum to 1.0 for each knob
+(: normalizeProbabilityDistributions (-> (Map NodeId (Map KnobValue Number)) (Map NodeId (Map KnobValue Number))))
+(= (normalizeProbabilityDistributions $smoothedCounts)
   (let* (
-        ($len (Map.length $inner))
+        ($n (Map.length $smoothedCounts))
       )
-      (laplace-smooth-inner-idx $inner $alpha 0 $len NilMap)))
+      (normalizeProbabilityDistributionsByIndex $smoothedCounts 0 $n NilMap)))
 
-(: laplace-smooth-inner-idx (-> (Map KnobValue Number) Number Number Number (Map KnobValue Number) (Map KnobValue Number)))
-(= (laplace-smooth-inner-idx $m $alpha $i $n $acc)
+;; Normalize probability distributions using index-based iteration
+(: normalizeProbabilityDistributionsByIndex (-> (Map NodeId (Map KnobValue Number)) Number Number (Map NodeId (Map KnobValue Number)) (Map NodeId (Map KnobValue Number))))
+(= (normalizeProbabilityDistributionsByIndex $smoothedCounts $i $n $acc)
   (if (>= $i $n)
       $acc
       (let* (
-            ($pair (Map.getByIdx $m $i))
-            (($kv $cnt) $pair)
-            ($acc2 (Map.insert ($kv (+ $cnt $alpha)) $acc knobValueEq knobValueLt))
+            ($pair (Map.getByIdx $smoothedCounts $i))
+            (($knobId $innerCounts) $pair)
+            ($normalizedInner (normalizeSingleKnobDistribution $innerCounts))
+            ($updatedAcc (Map.insert ($knobId $normalizedInner) $acc == nodeId<))
           )
-          (laplace-smooth-inner-idx $m $alpha (+ $i 1) $n $acc2))))
+          (normalizeProbabilityDistributionsByIndex $smoothedCounts (+ $i 1) $n $updatedAcc))))
 
-;; Normalize counts to probabilities
-(: normalize-counts (-> (Map KnobValue Number) (Map KnobValue Number)))
-(= (normalize-counts $counts)
+;; Normalize a single knob's distribution to probabilities
+;; Formula: P(k,v) = count[k][v] / Σ(count[k][v'] for all v')
+(: normalizeSingleKnobDistribution (-> (Map KnobValue Number) (Map KnobValue Number)))
+(= (normalizeSingleKnobDistribution $counts)
    (let* (
          ($n (Map.length $counts))
-         ($total (normalize-counts-sum $counts 0 $n 0))
+         ($total (calculateTotalCount $counts 0 $n 0))
        )
-       (normalize-counts-build $counts 0 $n $total NilMap)))
+       (buildNormalizedProbabilities $counts 0 $n $total NilMap)))
 
-(: normalize-counts-sum (-> (Map KnobValue Number) Number Number Number Number))
-(= (normalize-counts-sum $m $i $n $acc)
+;; Calculate total count for normalization
+(: calculateTotalCount (-> (Map KnobValue Number) Number Number Number Number))
+(= (calculateTotalCount $counts $i $n $acc)
    (if (>= $i $n)
        $acc
        (let* (
-             ($pair (Map.getByIdx $m $i))
-             (($k $cnt) $pair)
+             ($pair (Map.getByIdx $counts $i))
+             (($knobValue $count) $pair)
            )
-           (normalize-counts-sum $m (+ $i 1) $n (+ $acc $cnt)))))
+           (calculateTotalCount $counts (+ $i 1) $n (+ $acc $count)))))
 
-(: normalize-counts-build (-> (Map KnobValue Number) Number Number Number (Map KnobValue Number) (Map KnobValue Number)))
-(= (normalize-counts-build $m $i $n $total $acc)
+;; Build normalized probabilities from counts
+(: buildNormalizedProbabilities (-> (Map KnobValue Number) Number Number Number (Map KnobValue Number) (Map KnobValue Number)))
+(= (buildNormalizedProbabilities $counts $i $n $total $acc)
   (if (>= $i $n)
       $acc
       (let* (
-            ($pair (Map.getByIdx $m $i))
-            (($kv $cnt) $pair)
-            ($p (if (== $total 0) 0 (/ $cnt $total)))
-            ($acc2 (Map.insert ($kv $p) $acc knobValueEq knobValueLt))
+            ($pair (Map.getByIdx $counts $i))
+            (($knobValue $count) $pair)
+            ($probability (if (== $total 0) 0 (/ $count $total)))
+            ($updatedAcc (Map.insert ($knobValue $probability) $acc knobValueEq knobValueLt))
           )
-          (normalize-counts-build $m (+ $i 1) $n $total $acc2))))
+          (buildNormalizedProbabilities $counts (+ $i 1) $n $total $updatedAcc))))
 
 ;; ================================================================================
 ;; Helper Functions
 ;; ================================================================================
 
 ;; Get discrete map from representation
-; (: getDiscMap (-> Representation (MultiMap (DiscSpec $knob))))
+(: getDiscMap (-> Representation (MultiMap (DiscSpec $knob))))
 (= (getDiscMap (mkRep (mkKbMap $dscKbMp $dscMp) $tree)) (extractMultiMap $dscMp))
 
 ;; Extract MultiMap from DiscMap
-; (: extractMultiMap (-> DiscMap (MultiMap (DiscSpec $knob))))
+(: extractMultiMap (-> DiscMap (MultiMap (DiscSpec $knob))))
 (= (extractMultiMap (mkDscMp $multiMap)) $multiMap)
 
 ;; Comparison functions for KnobValue

--- a/optimization/eda/replacement.metta
+++ b/optimization/eda/replacement.metta
@@ -20,58 +20,52 @@
 ;; ================================================================================
 
 ;; Replace the worst instances in the population with new instances
-; (: replace-the-worst (-> (InstanceSet $score) Deme Deme))
-(= (replace-the-worst $newInstances $deme)
+(: replaceTheWorst (-> (InstanceSet $score) Deme Deme))
+(= (replaceTheWorst $newInstances $deme)
   (let* (
-        (() (println! (Replace-the-worst with $newInstances $deme)))
         ((mkDeme $rep (mkSInstSet $instSet) $id) $deme)
-        (() (println! (GOT $rep $instSet)))
         ((mkSInstSet $newList) $newInstances)
-        (() (println! (newList: $newList)))
-        ($scoredInstances $instSet)
-        ($nReplace (min (List.length $newList) (List.length $scoredInstances)))
-        (() (println! (N : $nReplace)))
-        ($worst (get-worst-instances $scoredInstances $nReplace))
-        (() (println! (worst : $worst)))
-        ($remaining (remove-worst-instances $scoredInstances $nReplace))
-        (() (println! (remaining : $remaining)))
-        ($updated (List.concat $remaining $newList))
-        (() (println! (updated : $updated)))
+        ($numToReplace (min (coll.length $newList) (coll.length $instSet)))
+        ((mkPair $worst $remaining) (getWorstAndRemaining $instSet $numToReplace))
+        ($incoming (List.takeN $numToReplace $newList))
+        ($updated (List.concat $remaining $incoming))
       )
       (mkDeme $rep (mkSInstSet $updated) $id)))
 
-;; Get the worst n instances
-; (: get-worst-instances (-> (List (ScoredInstance Cscore)) Number (List (ScoredInstance Cscore))))
-(= (get-worst-instances $instances $n)
+;; Optimized function to get both worst and remaining instances in one pass
+(: getWorstAndRemaining (-> (List (ScoredInstance $score)) Number (Pair (List (ScoredInstance $score)) (List (ScoredInstance $score)))))
+(= (getWorstAndRemaining $instances $n)
   (let* (
-        (() (println! (Get worst instances: instances= $instances)))
-        ($sorted (sort-by-score $instances))
-        (() (println! (Get worst instances: sorted= $sorted)))
-        ($len (List.length $sorted))
-        (() (println! (Get worst instances: len= $len)))
-        ($start (max 0 (- $len $n)))
+        ($sorted (sortByScore $instances))
+        ($len (coll.length $sorted))
+        ($keep (max 0 (- $len $n)))
+        ($remaining (List.takeN $keep $sorted))
+        ($worst (List.drop $keep $sorted))
       )
-      (List.drop $start $sorted)))
+      (mkPair $worst $remaining)))
+
+;; Get the worst n instances
+(: getWorstInstances (-> (List (ScoredInstance $score)) Number (List (ScoredInstance $score))))
+(= (getWorstInstances $instances $n)
+  (let* (
+        ((mkPair $worst $remaining) (getWorstAndRemaining $instances $n))
+      )
+      $worst))
 
 ;; Remove the worst n instances
-; (: remove-worst-instances (-> (List (ScoredInstance Cscore)) Number (List (ScoredInstance Cscore))))
-(= (remove-worst-instances $instances $n)
+(: removeWorstInstances (-> (List (ScoredInstance $score)) Number (List (ScoredInstance $score))))
+(= (removeWorstInstances $instances $n)
   (let* (
-        ($sorted (sort-by-score $instances))
-        ($len (List.length $sorted))
-        ($keep (max 0 (- $len $n)))
+        ((mkPair $worst $remaining) (getWorstAndRemaining $instances $n))
       )
-      (List.takeN $keep $sorted)))
+      $remaining))
 
-;; Sort instances by score (worst first)
-; (: sort-by-score (-> (List (ScoredInstance Cscore)) (List (ScoredInstance Cscore))))
-(= (sort-by-score $instances)
+;; Sort instances by score (descending best first from sortDeme, tail are worst)
+(: sortByScore (-> (List (ScoredInstance $score)) (List (ScoredInstance $score))))
+(= (sortByScore $instances)
   (let* (
-        (() (println! (Sort by score: instances= $instances)))
         ($set (mkSInstSet $instances))
-        (() (println! (Sort by score: set= $set)))
         ($sortedSet (sortDeme $set))
-        (() (println! (Sort by score: sortedSet= $sortedSet)))
       )
       (getScoredInstances $sortedSet)))
 

--- a/optimization/eda/sampling.metta
+++ b/optimization/eda/sampling.metta
@@ -1,104 +1,85 @@
 ;; ================================================================================
-;; Model Sampling
+;; Model Sampling (EDA)
 ;; ================================================================================
 ;;
-;; This file implements the model sampling policy for EDA.
-;; Equivalent to sampling logic in optimize.h in the C++ implementation.
+;; Purpose
+;; - Sample new instances from a learned univariate KnobProbabilityModel.
+;; - Create valid Instance values compatible with a Representation.
 ;;
-;; Key Components:
-;; - Sample new instances from the learned probability model
-;; - Generate instances from probability distributions
-;; - Sample knob values according to learned probabilities
-;; - Create instances from sampled knob values
-;;
-;; Sampling Strategy:
-;; - Uses learned probability distributions to generate new instances
-;; - Samples each knob independently (univariate assumption)
-;; - Creates valid instances compatible with the representation
+;; Notes
+;; - Univariate assumption: each knob is sampled independently.
+;; - Deterministic tests assert helper behavior; random sampling is not asserted.
 
 
 ;; Sample new instances from the learned probability model
-(: sample-from-model (-> (KnobProbabilityModel) Deme Number (InstanceSet $score)))
-(= (sample-from-model $probModel $deme $nGenerate)
-  (let* (
-        ((mkDeme $rep (mkSInstSet $instSet) $id) $deme)
-        ($newInstances (generate-instances $probModel $rep $nGenerate))
-        ($wrapped (List.map initInstScore $newInstances))
-      )
-      (mkSInstSet $wrapped)))
+(: sampleFromModel (-> (KnobProbabilityModel) Deme Number (InstanceSet $score)))
+(= (sampleFromModel $probModel $deme $nGenerate)
+  (if (<= $nGenerate 0)
+      (mkSInstSet Nil)  ; Return empty set for invalid nGenerate
+      (let* (
+            ((mkDeme $rep (mkSInstSet $instSet) $id) $deme)
+            ($newInstances (generateInstances $probModel $rep $nGenerate))
+            ($wrapped (List.map initInstScore $newInstances))
+          )
+          (mkSInstSet $wrapped))))
 
 ;; Helper functions moved to their appropriate files:
 ;; - getRep and getInstanceSet moved to deme/create-deme.metta
 ;; - getScoredInstances moved to representation/instance.metta
 
 ;; Generate new instances from the probability model
-(: generate-instances (-> (KnobProbabilityModel) Representation Number (List Instance)))
-(= (generate-instances $probModel $rep $nGenerate)
+(: generateInstances (-> (KnobProbabilityModel) Representation Number (List Instance)))
+(= (generateInstances $probModel $rep $nGenerate)
   (if (<= $nGenerate 0)
       Nil
       (let* (
-            ($newInstance (sample-instance $probModel $rep))
-            ($rest (generate-instances $probModel $rep (- $nGenerate 1)))
+            ($newInstance (sampleInstance $probModel $rep))
+            ($rest (generateInstances $probModel $rep (- $nGenerate 1)))
           )
           (Cons $newInstance $rest))))
 
 ;; Sample a single instance from the probability model
-(: sample-instance (-> (KnobProbabilityModel) Representation Instance))
-(= (sample-instance $probModel $rep)
+(: sampleInstance (-> (KnobProbabilityModel) Representation Instance))
+(= (sampleInstance $probModel $rep)
    (let* (
-         ($knobValues (sample-knob-values $probModel $rep))
-         ($instance (create-instance $rep $knobValues))
+         ($knobValues (sampleKnobValues $probModel $rep))
+         ($instance (createInstance $rep $knobValues))
        )
        $instance))
 
 ;; Sample knob values according to learned probabilities
-; (: sample-knob-values (-> (KnobProbabilityModel) Representation (Map NodeId KnobValue)))
-(= (sample-knob-values $probModel $rep)
+; (: sampleKnobValues (-> (KnobProbabilityModel) Representation (Map NodeId KnobValue)))
+(= (sampleKnobValues $probModel $rep)
   (let* (
-        (() (println! (sample-knob-values: probModel= $probModel rep= $rep)))
-        (() (println! (sample-knob-values: about to destructure rep)))
         ((mkRep (mkKbMap $discKbMp $discMp) $tree) $rep)
-        (() (println! (sample-knob-values: discKbMp= $discKbMp discMp= $discMp tree= $tree)))
-        (() (println! (sample-knob-values: about to destructure discKbMp)))
         ((mkDscKbMp $discKbMap) $discKbMp)
-        (() (println! (sample-knob-values: discKbMap= $discKbMap)))
         ($knobIds (Map.keys $discKbMap))
-        (() (println! (sample-knob-values: knobIds= $knobIds)))
-        (() (println! (sample-knob-values: about to call sample-knob-values-acc)))
-        ($knobValues (sample-knob-values-acc $probModel $knobIds NilMap))
-        (() (println! (sample-knob-values: knobValues= $knobValues)))
+        ($knobValues (sampleKnobValuesAcc $probModel $knobIds NilMap))
       )
       $knobValues))
 
 ;; Helper to accumulate sampled knob values - build map manually to avoid comparison issues
-(: sample-knob-values-acc (-> (KnobProbabilityModel) (List NodeId) (Map NodeId KnobValue) (Map NodeId KnobValue)))
-(= (sample-knob-values-acc $probModel Nil $acc) 
+(: sampleKnobValuesAcc (-> (KnobProbabilityModel) (List NodeId) (Map NodeId KnobValue) (Map NodeId KnobValue)))
+(= (sampleKnobValuesAcc $probModel Nil $acc) $acc)
+(= (sampleKnobValuesAcc $probModel (Cons $kid $rest) $acc)
   (let* (
-        (() (println! (sample-knob-values-acc: base case, returning acc= $acc)))
-      )
-      $acc))
-(= (sample-knob-values-acc $probModel (Cons $kid $rest) $acc)
-  (let* (
-        (() (println! (sample-knob-values-acc: processing kid= $kid rest= $rest acc= $acc)))
-        ($val (sample-knob-value $probModel $kid))
-        (() (println! (sample-knob-values-acc: got val= $val)))
+        ($val (sampleKnobValue $probModel $kid))
         ($acc2 (ConsMap ($kid $val) $acc))
-        (() (println! (sample-knob-values-acc: got acc2= $acc2)))
       )
-      (sample-knob-values-acc $probModel $rest $acc2)))
+      (sampleKnobValuesAcc $probModel $rest $acc2)))
 
 ;; Sample a single knob value
-(: sample-knob-value (-> (KnobProbabilityModel) NodeId KnobValue))
-(= (sample-knob-value $probModel $knobId)
+(: sampleKnobValue (-> (KnobProbabilityModel) NodeId KnobValue))
+(= (sampleKnobValue $probModel $knobId)
    (let* (
-         ($probabilities (get-knob-probabilities $probModel $knobId))
-         ($randomValue (random-from-distribution $probabilities))
+         ($probabilities (getKnobProbabilities $probModel $knobId))
+         ($randomValue (randomFromDistribution $probabilities))
        )
        $randomValue))
 
 ;; Get knob probabilities from model
-(: get-knob-probabilities (-> (KnobProbabilityModel) NodeId (Map KnobValue Number)))
-(= (get-knob-probabilities (mkKnobProbabilityModel $probabilities) $knobId)
+(: getKnobProbabilities (-> (KnobProbabilityModel) NodeId (Map KnobValue Number)))
+(= (getKnobProbabilities (mkKnobProbabilityModel $probabilities) $knobId)
    (let* (
          ($idx (Map.find $probabilities $knobId))
        )
@@ -107,44 +88,46 @@
            (let ($k $v) (Map.getByIdx $probabilities $idx) $v))))
 
 ;; Random selection from distribution
-(: random-from-distribution (-> (Map KnobValue Number) KnobValue))
-(= (random-from-distribution $probabilities)
-   (let* (
-         ($random (randomFloat))
-         ($items (Map.items $probabilities))
-       )
-       (select-from-cumulative-list $items $random 0.0)))
+(: randomFromDistribution (-> (Map KnobValue Number) KnobValue))
+(= (randomFromDistribution $probabilities)
+   (if (== (Map.length $probabilities) 0)
+       (mkKnobValue 0)  ; Return default value for empty distribution
+       (let* (
+             ($random (randomFloat))
+             ($items (Map.items $probabilities))
+           )
+           (selectFromCumulativeList $items $random 0.0))))
 
 ;; Select value based on cumulative probability
-(: select-from-cumulative-list (-> (List (KnobValue Number)) Number Number KnobValue))
-(= (select-from-cumulative-list Nil $target $cumulative) (mkKnobValue 0))
-(= (select-from-cumulative-list (Cons ($value $prob) $tail) $target $cumulative)
+(: selectFromCumulativeList (-> (List (KnobValue Number)) Number Number KnobValue))
+(= (selectFromCumulativeList Nil $target $cumulative) (mkKnobValue 0))
+(= (selectFromCumulativeList (Cons ($value $prob) $tail) $target $cumulative)
    (let* (
          ($newCumulative (+ $cumulative $prob))
        )
        (if (>= $newCumulative $target)
            $value
-           (select-from-cumulative-list $tail $target $newCumulative))))
+           (selectFromCumulativeList $tail $target $newCumulative))))
 
 ;; Create instance from knob values
-(: create-instance (-> Representation (Map NodeId KnobValue) Instance))
-(= (create-instance (mkRep (mkKbMap (mkDscKbMp $discKbMap) (mkDscMp $discMap)) $tree) $knobValues)
+(: createInstance (-> Representation (Map NodeId KnobValue) Instance))
+(= (createInstance (mkRep (mkKbMap (mkDscKbMp $discKbMap) (mkDscMp $discMap)) $tree) $knobValues)
    (let* (
          ($n (MultiMap.length $discMap))
          ($zeros (List.generate $n 0))
-         ($filled (fill-instance-by-map $zeros $discKbMap $knobValues))
+         ($filled (fillInstanceByMap $zeros $discKbMap $knobValues))
        )
        (mkInst $filled)))
 
-(: fill-instance-by-map (-> (List Number) (Map (NodeId Number)) (Map NodeId KnobValue) (List Number)))
-(= (fill-instance-by-map $vec $discKbMap NilMap) $vec)
-(= (fill-instance-by-map $vec $discKbMap (ConsMap ($kid $val) $tail))
+(: fillInstanceByMap (-> (List Number) (Map (NodeId Number)) (Map NodeId KnobValue) (List Number)))
+(= (fillInstanceByMap $vec $discKbMap NilMap) $vec)
+(= (fillInstanceByMap $vec $discKbMap (ConsMap ($kid $val) $tail))
    (let* (
          ($idx (Map.getByKey $kid $discKbMap))
         ($valNum (getKnobValue $val))
         ($newVec (List.replaceAt $vec $idx $valNum))
       )
-      (fill-instance-by-map $newVec $discKbMap $tail)))
+      (fillInstanceByMap $newVec $discKbMap $tail)))
 
 ;; ================================================================================
 ;; Helper Functions

--- a/optimization/eda/selection.metta
+++ b/optimization/eda/selection.metta
@@ -1,37 +1,34 @@
 ;; ================================================================================
-;; Selection Policy (Tournament Selection)
+;; Selection Policy (Tournament)
 ;; ================================================================================
 ;;
-;; This file implements the selection policy for EDA.
-;; Equivalent to selection logic in optimize.h in the C++ implementation.
+;; Purpose
+;; - Select promising individuals via tournament selection.
+;; - Maintain diversity by sampling k random participants per tournament.
 ;;
-;; Key Components:
-;; - Tournament selection for selecting promising individuals
-;; - Random K selection for tournament participants
-;; - Best individual selection from tournament participants
-;;
-;; Selection Strategy:
-;; - Uses tournament selection to maintain diversity
-;; - Selects n individuals using tournament selection
-;; - Each tournament selects the best from k random participants
+;; Notes
+;; - Non-deterministic due to randomness; tests check sizes, not identities.
 
 ;; ================================================================================
 ;; Selection Policy (Tournament Selection)
 ;; ================================================================================
 
 ;; Tournament selection - select n individuals using tournament selection
-(: tournament-selection (-> Number Deme Number (InstanceSet $score)))
-(= (tournament-selection $tournamentSize $deme $nSelect)
+(: tournamentSelection (-> Number Deme Number (InstanceSet $score)))
+(= (tournamentSelection $tournamentSize $deme $nSelect)
    (let* (
          ((mkDeme $rep (mkSInstSet $instSet) $id) $deme)
          ($scoredInstances $instSet)
-         ($selected (select-tournament $tournamentSize $scoredInstances $nSelect))
+         ;; Assert valid parameters
+         ($validTournamentSize (if (<= $tournamentSize 0) 1 $tournamentSize))
+         ($validNSelect (if (<= $nSelect 0) 0 $nSelect))
+         ($selected (selectTournament $validTournamentSize $scoredInstances $validNSelect))
        )
        (mkSInstSet $selected)))
 
 ;; Select individuals using tournament selection
-(: select-tournament (-> Number (List (ScoredInstance $score)) Number (List (ScoredInstance $score))))
-(= (select-tournament $tournamentSize $instances $nSelect)
+(: selectTournament (-> Number (List (ScoredInstance $score)) Number (List (ScoredInstance $score))))
+(= (selectTournament $tournamentSize $instances $nSelect)
   (let* (
         ($len (coll.length $instances))
         ($need (min $nSelect $len))
@@ -40,53 +37,77 @@
       (if (or (<= $need 0) (<= $len 0))
           Nil
           (let* (
-                ((mkPair $winner $remainingAfter) (run-tournament $ts $instances))
-                ($rest (select-tournament $ts $remainingAfter (- $need 1)))
+                ((mkPair $winner $remainingAfter) (runTournament $ts $instances))
+                ($rest (selectTournament $ts $remainingAfter (- $need 1)))
               )
               (Cons $winner $rest)))))
 
 ;; Run a single tournament
-(: run-tournament (-> Number (List (ScoredInstance $score)) (Pair (ScoredInstance $score) (List (ScoredInstance $score)))))
-(= (run-tournament $tournamentSize $instances)
+(: runTournament (-> Number (List (ScoredInstance $score)) (Pair (ScoredInstance $score) (List (ScoredInstance $score)))))
+(= (runTournament $tournamentSize $instances)
   (let* (
-        ((mkPair $participants $rest) (select-random-k $tournamentSize $instances))
-        ($winner (if (== (coll.length $participants) 0)
-                     (coll.getByIdx $instances 0)
-                     (select-best $participants)))
+        ((mkPair $participants $rest) (selectRandomK $tournamentSize $instances))
+        ($winner (selectTournamentWinner $participants $instances))
         ($participantsTail (List.tail $participants))
         ($remainingAfter (List.concat $rest $participantsTail))
       )
       (mkPair $winner $remainingAfter)))
 
+;; Helper function to select tournament winner
+(: selectTournamentWinner (-> (List (ScoredInstance $score)) (List (ScoredInstance $score)) (ScoredInstance $score)))
+(= (selectTournamentWinner $participants $instances)
+  (if (== (coll.length $participants) 0)
+      (if (== (coll.length $instances) 0)
+          (getDefaultWorstInstance)  ; Both empty - return default
+          (coll.getByIdx $instances 0))  ; Participants empty - use first instance
+      (selectBest $participants)))  ; Participants available - select best
+
 ;; Select random K participants
-(: select-random-k (-> Number (List (ScoredInstance $score)) (Pair (List (ScoredInstance $score)) (List (ScoredInstance $score)))))
-(= (select-random-k $k $instances)
+(: selectRandomK (-> Number (List (ScoredInstance $score)) (mkPair (List (ScoredInstance $score)) (List (ScoredInstance $score)))))
+(= (selectRandomK $k $instances)
   (if (or (<= $k 0) (== (coll.length $instances) 0))
       (mkPair Nil $instances)
-      (let* (
-            ($len (coll.length $instances))
-            ($rf (randomFloat))
-            ($idx (int (* $rf $len)))
-            ($safeIdx (if (== $idx $len) (- $len 1) $idx))
-            ($selected (coll.getByIdx $instances $safeIdx))
-            ($remaining (coll.removeByIdx $instances $safeIdx))
-            ((mkPair $restSel $restRem) (select-random-k (- $k 1) $remaining))
-          )
-          (mkPair (Cons $selected $restSel) $restRem))))
+      (if (> $k (coll.length $instances))
+          (mkPair $instances Nil)  ; Return all instances if k > length
+          (selectRandomKHelper $k $instances))))
+
+;; Helper function to reduce nesting in selectRandomK
+(: selectRandomKHelper (-> Number (List (ScoredInstance $score)) (Pair (List (ScoredInstance $score)) (List (ScoredInstance $score)))))
+(= (selectRandomKHelper $k $instances)
+  (let* (
+        ($len (coll.length $instances))
+        ($rf (randomFloat))
+        ($idx (int (* $rf $len)))
+        ($safeIdx (if (== $idx $len) (- $len 1) $idx))
+        ($selected (coll.getByIdx $instances $safeIdx))
+        ($remaining (coll.removeByIdx $instances $safeIdx))
+        ((mkPair $restSel $restRem) (selectRandomK (- $k 1) $remaining))
+      )
+      (mkPair (Cons $selected $restSel) $restRem)))
 
 
 ;; Select best individual from list
-(: select-best (-> (List (ScoredInstance $score)) (ScoredInstance $score)))
-(= (select-best $instances)
+(: selectBest (-> (List (ScoredInstance $score)) (ScoredInstance $score)))
+(= (selectBest $instances)
   (if (== (coll.length $instances) 0)
-      (coll.getByIdx (Cons (mkSInst (mkPair (mkInst Nil) (worstCscore))) Nil) 0)
-      (let* (
-            ($head (coll.getByIdx $instances 0))
-            ($tail (List.drop 1 $instances))
-          )
-          (List.foldl select-best-step $head $tail))))
+      (getDefaultWorstInstance)
+      (selectBestFromNonEmpty $instances)))
 
-(: select-best-step (-> (ScoredInstance $score) (ScoredInstance $score) (ScoredInstance $score)))
-(= (select-best-step $bestSoFar $candidate)
+;; Helper function to get default worst instance
+(: getDefaultWorstInstance (-> (ScoredInstance $score)))
+(= (getDefaultWorstInstance)
+  (coll.getByIdx (Cons (mkSInst (mkPair (mkInst Nil) (worstCscore))) Nil) 0))
+
+;; Helper function to select best from non-empty list
+(: selectBestFromNonEmpty (-> (List (ScoredInstance $score)) (ScoredInstance $score)))
+(= (selectBestFromNonEmpty $instances)
+  (let* (
+        ($head (coll.getByIdx $instances 0))
+        ($tail (List.drop 1 $instances))
+      )
+      (List.foldl selectBestStep $head $tail)))
+
+(: selectBestStep (-> (ScoredInstance $score) (ScoredInstance $score) (ScoredInstance $score)))
+(= (selectBestStep $bestSoFar $candidate)
   (if (apply >= $candidate $bestSoFar) $candidate $bestSoFar))
 

--- a/optimization/eda/termination.metta
+++ b/optimization/eda/termination.metta
@@ -21,33 +21,31 @@
 ;; ================================================================================
 
 ;; Check if optimization should terminate
-(: terminate-if-gte-or-no-improv (-> Number Number Deme Bool))
-(= (terminate-if-gte-or-no-improv $threshold $maxGensNoImprovement $deme)
-  (let* (
-        (() (println! (Terminate if gte or no improv: threshold= $threshold maxGensNoImprovement= $maxGensNoImprovement deme= $deme)))
-        ((mkDeme $rep $iset $id) $deme)
-        (() (println! (Terminate if gte or no improv: iset= $iset)))
-        ($best (get-best-penalized-score $iset))
-        (() (println! (Terminate if gte or no improv: best= $best)))
-      )
-      (if (< $best $threshold) False True)))
+;; This implements the full C++ logic: terminate if score >= threshold OR no improvement for maxGensNoImprovement generations
+(: terminateIfGteOrNoImprov (-> Number Number Deme Number Number Number Bool))
+(= (terminateIfGteOrNoImprov $threshold $maxGensNoImprovement $deme $bestSeenSoFar $generationsWithoutImprovement)
+  (if (< $maxGensNoImprovement 0)
+      False  ; Invalid maxGensNoImprovement - don't terminate
+      (let* (
+            ($currentBest (getBestPenalizedScore (getInstanceSet $deme)))
+            ($hasImproved (> $currentBest $bestSeenSoFar))
+          )
+          ;; C++ logic: if improved, only check threshold; if no improvement, check both conditions
+          (if $hasImproved
+              (>= $currentBest $threshold)  ; Use type-safe >= from general-helpers
+              (or (>= $generationsWithoutImprovement $maxGensNoImprovement)  ; Check OLD no-improvement count
+                  (>= $bestSeenSoFar $threshold))))))  ; Use type-safe >= from general-helpers
 
 ;; Get the best penalized score from the instance set
-(: get-best-penalized-score (-> (InstanceSet Cscore) Number))
-(= (get-best-penalized-score (mkSInstSet $instances))
+(: getBestPenalizedScore (-> (InstanceSet Cscore) Number))
+(= (getBestPenalizedScore (mkSInstSet $instances))
   (if (== (List.length $instances) 0)
       (getPenScore (worstCscore))
-      (let* (
-            ;; Extract penalized scores from scored instances via a named helper
-            ($scores (List.map get-pen-score-from-sinst $instances))
-            ;; Compute the maximum penalized score
-            ($best (List.max $scores))
-          )
-          $best)))
+      (List.max (List.map getPenScoreFromSinst $instances))))
 
 ;; Helper: extract penalized score from a ScoredInstance
-(: get-pen-score-from-sinst (-> (ScoredInstance Cscore) Number))
-(= (get-pen-score-from-sinst (mkSInst (mkPair $inst $cs))) (getPenScore $cs))
+(: getPenScoreFromSinst (-> (ScoredInstance Cscore) Number))
+(= (getPenScoreFromSinst (mkSInst (mkPair $inst $cs))) (getPenScore $cs))
 
 ;; ================================================================================
 ;; Future Termination Policies
@@ -56,19 +54,19 @@
 ;; Placeholder for additional termination criteria
 ;; These could be implemented for more sophisticated termination strategies
 
-;; (: terminate-if-max-generations (-> Number Number Bool))
+;; (: terminateIfMaxGenerations (-> Number Number Bool))
 ;; (= (terminate-if-max-generations $currentGen $maxGens)
 ;;    (>= $currentGen $maxGens))
 
-;; (: terminate-if-convergence (-> Deme Number Bool))
-;; (= (terminate-if-convergence $deme $tolerance)
+;; (: terminateIfConvergence (-> Deme Number Bool))
+;; (= (terminateIfConvergence $deme $tolerance)
 ;;    (let* (
 ;;          ($variance (compute-population-variance $deme))
 ;;        )
 ;;        (< $variance $tolerance)))
 
-;; (: terminate-if-time-limit (-> Number Number Bool))
-;; (= (terminate-if-time-limit $startTime $maxTime)
+;; (: terminateIfTimeLimit (-> Number Number Bool))
+;; (= (terminateIfTimeLimit $startTime $maxTime)
 ;;    (let* (
 ;;          ($currentTime (perf_counter))
 ;;          ($elapsed (- $currentTime $startTime))

--- a/optimization/eda/test/eda-parameters-test.metta
+++ b/optimization/eda/test/eda-parameters-test.metta
@@ -13,11 +13,11 @@
 !(assertEqual (getModelComplexity (mkEDAParameters 2 1.0 0.5 1.0)) 1.0)
 
 ; ;; Test default parameters
-!(assertEqual (getSelection (default-eda-parameters)) 2)
-!(assertEqual (getSelectionRatio (default-eda-parameters)) 1.0)
-!(assertEqual (getReplacementRatio (default-eda-parameters)) 0.5)
-!(assertEqual (getModelComplexity (default-eda-parameters)) 1.0)
+!(assertEqual (getSelection (defaultEdaParameters)) 2)
+!(assertEqual (getSelectionRatio (defaultEdaParameters)) 1.0)
+!(assertEqual (getReplacementRatio (defaultEdaParameters)) 0.5)
+!(assertEqual (getModelComplexity (defaultEdaParameters)) 1.0)
 
 ; ;; Test parameter types
 !(assertEqual (get-type (mkEDAParameters 2 1.0 0.5 1.0)) (EDAParameters))
-!(assertEqual (let $params (default-eda-parameters) (get-type $params)) (EDAParameters))
+!(assertEqual (let $params (defaultEdaParameters) (get-type $params)) (EDAParameters))

--- a/optimization/eda/test/initialization-test.metta
+++ b/optimization/eda/test/initialization-test.metta
@@ -28,11 +28,11 @@
   (mkTree (mkNode AND) (Cons (mkNullVex (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode B) Nil) Nil)) Nil)))))
 
 ;; Deterministic checks (no get-type, no bind). For exact asserts, use multiplicity-1 representation.
-!(assertEqual (coll.length (get-knob-ids-and-specs test_rep)) 2)
+!(assertEqual (coll.length (getKnobIdsAndSpecs test_rep)) 2)
 
 ;; Multiplicity-1 rep produces fully deterministic uniform values
 !(assertEqual 
-  (get-knob-ids-and-specs 
+  (getKnobIdsAndSpecs 
     (mkRep (mkKbMap (mkDscKbMp (ConsMap ((mkNodeId (1)) 0) (ConsMap ((mkNodeId (2)) 1) NilMap)))
                     (mkDscMp (ConsMMap ((mkDiscSpec 1) (mkLSK (mkDiscKnob (mkKnob (mkNodeId (1))) (mkMultip 1) (mkDiscSpec 0) (mkDiscSpec 0) Nil)))
                                       (ConsMMap ((mkDiscSpec 1) (mkLSK (mkDiscKnob (mkKnob (mkNodeId (2))) (mkMultip 1) (mkDiscSpec 0) (mkDiscSpec 0) Nil))) NilMMap))))
@@ -41,7 +41,7 @@
         (Cons ((mkNodeId (2)) (mkLSK (mkDiscKnob (mkKnob (mkNodeId (2))) (mkMultip 1) (mkDiscSpec 0) (mkDiscSpec 0) Nil))) Nil)))
 
 !(assertEqual 
-  (sample-uniform-knob-values 
+  (sampleUniformKnobValues 
     (mkRep (mkKbMap (mkDscKbMp (ConsMap ((mkNodeId (1)) 0) (ConsMap ((mkNodeId (2)) 1) NilMap)))
                     (mkDscMp (ConsMMap ((mkDiscSpec 1) (mkLSK (mkDiscKnob (mkKnob (mkNodeId (1))) (mkMultip 1) (mkDiscSpec 0) (mkDiscSpec 0) Nil)))
                                       (ConsMMap ((mkDiscSpec 1) (mkLSK (mkDiscKnob (mkKnob (mkNodeId (2))) (mkMultip 1) (mkDiscSpec 0) (mkDiscSpec 0) Nil))) NilMMap))))
@@ -49,17 +49,17 @@
   (ConsMap ((mkNodeId (1)) (mkKnobValue 0)) (ConsMap ((mkNodeId (2)) (mkKnobValue 0)) NilMap)))
 
 !(assertEqual 
-  (sample-uniform-instance 
+  (sampleUniformInstance 
     (mkRep (mkKbMap (mkDscKbMp (ConsMap ((mkNodeId (1)) 0) (ConsMap ((mkNodeId (2)) 1) NilMap)))
                     (mkDscMp (ConsMMap ((mkDiscSpec 1) (mkLSK (mkDiscKnob (mkKnob (mkNodeId (1))) (mkMultip 1) (mkDiscSpec 0) (mkDiscSpec 0) Nil)))
                                       (ConsMMap ((mkDiscSpec 1) (mkLSK (mkDiscKnob (mkKnob (mkNodeId (2))) (mkMultip 1) (mkDiscSpec 0) (mkDiscSpec 0) Nil))) NilMMap))))
            (mkTree (mkNode AND) (Cons (mkNullVex (Cons (mkTree (mkNode A) Nil) Nil)) (Cons (mkNullVex (Cons (mkTree (mkNode B) Nil) Nil)) Nil)))))
   (mkInst (Cons 0 (Cons 0 Nil))))
 
-;; sample-uniform-kv-acc explicit cases
-!(assertEqual (sample-uniform-kv-acc Nil NilMap) NilMap)
+;; sampleUniformKvAcc explicit cases
+!(assertEqual (sampleUniformKvAcc Nil NilMap) NilMap)
 !(assertEqual 
-  (sample-uniform-kv-acc 
+  (sampleUniformKvAcc 
     (Cons ((mkNodeId (1)) (mkDiscSpec 1)) (Cons ((mkNodeId (2)) (mkDiscSpec 1)) Nil)) 
     NilMap)
   (ConsMap ((mkNodeId (1)) (mkKnobValue 0)) (ConsMap ((mkNodeId (2)) (mkKnobValue 0)) NilMap)))

--- a/optimization/eda/test/probability-learning-test.metta
+++ b/optimization/eda/test/probability-learning-test.metta
@@ -44,14 +44,14 @@
   (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 2 Nil))) (mkCscore -3 1 0.5 0.0 -3.5))) Nil))))))
 
 ;; Test knob value counting (deterministic counts)
-!(assertEqual (count-knob-values (getDiscMap (getRep test_deme)) test_instances)
+!(assertEqual (countKnobValues (getDiscMap (getRep test_deme)) test_instances)
   (ConsMap ((mkNodeId (1)) (ConsMap ((mkKnobValue 0) 2) (ConsMap ((mkKnobValue 1) 2) NilMap)))
            (ConsMap ((mkNodeId (2)) (ConsMap ((mkKnobValue 0) 1) (ConsMap ((mkKnobValue 1) 2) (ConsMap ((mkKnobValue 2) 1) NilMap)))) NilMap)))
 
 ;; Test probability computation (Laplace-smoothed, normalized)
-!(assertEqual (Map.getByKey (mkNodeId (1)) (compute-probabilities (count-knob-values (getDiscMap (getRep test_deme)) test_instances)))
+!(assertEqual (Map.getByKey (mkNodeId (1)) (computeProbabilities (countKnobValues (getDiscMap (getRep test_deme)) test_instances)))
   (ConsMap ((mkKnobValue 0) 0.5) (ConsMap ((mkKnobValue 1) 0.5) NilMap)))
-!(assertEqual (Map.getByKey (mkNodeId (2)) (compute-probabilities (count-knob-values (getDiscMap (getRep test_deme)) test_instances)))
+!(assertEqual (Map.getByKey (mkNodeId (2)) (computeProbabilities (countKnobValues (getDiscMap (getRep test_deme)) test_instances)))
   (ConsMap ((mkKnobValue 0) (/ 2.0 7.0)) (ConsMap ((mkKnobValue 1) (/ 3.0 7.0)) (ConsMap ((mkKnobValue 2) (/ 2.0 7.0)) NilMap))))
 
 ; ;; Test KnobValue comparison functions

--- a/optimization/eda/test/replacement-test.metta
+++ b/optimization/eda/test/replacement-test.metta
@@ -37,19 +37,19 @@
 
 ;; Worst instance identification returns last 2 after sort-by-score (descending best first)
 !(assertEqual 
-  (get-worst-instances (getScoredInstances (getInstanceSet test_deme)) 2)
+  (getWorstInstances (getScoredInstances (getInstanceSet test_deme)) 2)
   (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 Nil))) (mkCscore -1 1 0.5 0.0 -1.5)))
         (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 2 Nil))) (mkCscore -3 1 0.5 0.0 -3.5))) Nil)))
 
 ;; Removing worst 2 keeps the better 2
 !(assertEqual 
-  (remove-worst-instances (getScoredInstances (getInstanceSet test_deme)) 2)
+  (removeWorstInstances (getScoredInstances (getInstanceSet test_deme)) 2)
   (Cons (mkSInst (mkPair (mkInst (Cons 1 (Cons 1 Nil))) (mkCscore 0 2 1.0 0.0 -1.0)))
         (Cons (mkSInst (mkPair (mkInst (Cons 1 (Cons 0 Nil))) (mkCscore -1 1 0.5 0.0 -1.5))) Nil)))
 
 ;; sort-by-score sorts descending by penalized score then ascending complexity
 !(assertEqual 
-  (sort-by-score (getScoredInstances (getInstanceSet test_deme)))
+  (sortByScore (getScoredInstances (getInstanceSet test_deme)))
   (Cons (mkSInst (mkPair (mkInst (Cons 1 (Cons 1 Nil))) (mkCscore 0 2 1.0 0.0 -1.0)))
         (Cons (mkSInst (mkPair (mkInst (Cons 1 (Cons 0 Nil))) (mkCscore -1 1 0.5 0.0 -1.5)))
               (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 Nil))) (mkCscore -1 1 0.5 0.0 -1.5)))
@@ -57,7 +57,7 @@
 
 ;; Replacement inserts new instances and removes worst (assert on instance set)
 !(assertEqual 
-  (getInstanceSet (replace-the-worst (mkSInstSet (Cons (mkSInst (mkPair (mkInst (Cons 2 (Cons 2 Nil))) (mkCscore 1 2 1.0 0.0 0.0))) Nil)) test_deme))
+  (getInstanceSet (replaceTheWorst (mkSInstSet (Cons (mkSInst (mkPair (mkInst (Cons 2 (Cons 2 Nil))) (mkCscore 1 2 1.0 0.0 0.0))) Nil)) test_deme))
   (mkSInstSet (Cons (mkSInst (mkPair (mkInst (Cons 1 (Cons 1 Nil))) (mkCscore 0 2 1.0 0.0 -1.0)))
                    (Cons (mkSInst (mkPair (mkInst (Cons 1 (Cons 0 Nil))) (mkCscore -1 1 0.5 0.0 -1.5)))
                          (Cons (mkSInst (mkPair (mkInst (Cons 0 (Cons 1 Nil))) (mkCscore -1 1 0.5 0.0 -1.5)))

--- a/optimization/eda/test/sampling-test.metta
+++ b/optimization/eda/test/sampling-test.metta
@@ -46,13 +46,13 @@
 
 ;; Deterministic checks (avoid randomness in unit tests)
 
-;; get-knob-probabilities should return the exact map for a knob id
+;; getKnobProbabilities should return the exact map for a knob id
 !(assertEqual
-  (get-knob-probabilities test_prob_model (mkNodeId (1)))
+  (getKnobProbabilities test_prob_model (mkNodeId (1)))
   (ConsMap ((mkKnobValue 0) 0.3) (ConsMap ((mkKnobValue 1) 0.4) (ConsMap ((mkKnobValue 2) 0.3) NilMap))))
 
 !(assertEqual
-  (get-knob-probabilities test_prob_model (mkNodeId (2)))
+  (getKnobProbabilities test_prob_model (mkNodeId (2)))
   (ConsMap ((mkKnobValue 0) 0.2) (ConsMap ((mkKnobValue 1) 0.5) (ConsMap ((mkKnobValue 2) 0.3) NilMap))))
 
 ;; getKnobValue should unwrap the number
@@ -60,14 +60,14 @@
 
 ;; Test random distribution selection helper with deterministic target (cumulative 0.3, 0.7, 1.0)
 !(assertEqual 
-  (select-from-cumulative-list 
+  (selectFromCumulativeList 
      (Cons ((mkKnobValue 0) 0.3) (Cons ((mkKnobValue 1) 0.4) (Cons ((mkKnobValue 2) 0.3) Nil))) 
      0.5 0.0) 
   (mkKnobValue 1))
 
-;; Create-instance should fill indices correctly using the disc knob map
+;; createInstance should fill indices correctly using the disc knob map
 !(assertEqual 
-  (select-from-cumulative-list 
+  (selectFromCumulativeList 
      (Cons ((mkKnobValue 0) 0.3) (Cons ((mkKnobValue 1) 0.4) (Cons ((mkKnobValue 2) 0.3) Nil))) 
      0.5 0.0) 
   (mkKnobValue 1))
@@ -75,7 +75,7 @@
 ; Randomized sampling functions are not asserted here to keep tests deterministic
 ;; Deterministic sampling using a degenerate probability model
 !(assertEqual 
-  (sample-knob-values 
+  (sampleKnobValues 
      (mkKnobProbabilityModel (ConsMap 
         ((mkNodeId (1)) (ConsMap ((mkKnobValue 2) 1.0) NilMap))
         (ConsMap 
@@ -85,7 +85,7 @@
   (ConsMap ((mkNodeId (2)) (mkKnobValue 2)) (ConsMap ((mkNodeId (1)) (mkKnobValue 2)) NilMap)))
 
 !(assertEqual 
-  (sample-instance 
+  (sampleInstance 
      (mkKnobProbabilityModel (ConsMap 
         ((mkNodeId (1)) (ConsMap ((mkKnobValue 2) 1.0) NilMap))
         (ConsMap 
@@ -95,7 +95,7 @@
   (mkInst (Cons 2 (Cons 2 Nil))))
 
 !(assertEqual 
-  (coll.length (generate-instances 
+  (coll.length (generateInstances 
      (mkKnobProbabilityModel (ConsMap 
         ((mkNodeId (1)) (ConsMap ((mkKnobValue 2) 1.0) NilMap))
         (ConsMap 
@@ -106,6 +106,6 @@
 
 ; Randomized model sampling intentionally not asserted deterministically
 !(assertEqual 
-  (create-instance (getRep test_deme) 
+  (createInstance (getRep test_deme) 
      (ConsMap ((mkNodeId (1)) (mkKnobValue 1)) (ConsMap ((mkNodeId (2)) (mkKnobValue 2)) NilMap))) 
   (mkInst (Cons 1 (Cons 2 Nil))))

--- a/optimization/eda/test/selection-test.metta
+++ b/optimization/eda/test/selection-test.metta
@@ -35,17 +35,17 @@
 ;; Test best selection with actual instances
 ;; The best penalized score among the four is -1.0 for instance (1 1)
 !(assertEqual 
-  (select-best (getScoredInstances (getInstanceSet test_deme)))
+  (selectBest (getScoredInstances (getInstanceSet test_deme)))
   (mkSInst (mkPair (mkInst (Cons 1 (Cons 1 Nil))) (mkCscore 0 2 1.0 0.0 -1.0))))
 
 ;; Test tournament selection - note: this test is non-deterministic due to random selection
 ;; We test that it returns the correct number of instances rather than specific values
 !(assertEqual
-  (coll.length (getScoredInstances (tournament-selection 2 test_deme 1)))
+  (coll.length (getScoredInstances (tournamentSelection 2 test_deme 1)))
   1)
 
 ;; Test tournament selection with 2 selections
 !(assertEqual
-  (coll.length (getScoredInstances (tournament-selection 2 test_deme 2)))
+  (coll.length (getScoredInstances (tournamentSelection 2 test_deme 2)))
   2)
 

--- a/optimization/eda/test/termination-test.metta
+++ b/optimization/eda/test/termination-test.metta
@@ -34,11 +34,15 @@
   0))
 
 ;; Test termination condition
-!(assertEqual (terminate-if-gte-or-no-improv -1 10 test_deme) True)
-!(assertEqual (terminate-if-gte-or-no-improv 10 10 test_deme) False)
+
+;; Test full termination logic with improvement tracking
+!(assertEqual (terminateIfGteOrNoImprov -1 10 test_deme -2.0 0) True)  ; current(-1.0) > best(-2.0), and -1.0 >= -1
+!(assertEqual (terminateIfGteOrNoImprov 10 10 test_deme -2.0 0) False)  ; current(-1.0) > best(-2.0), but -1.0 < 10
+!(assertEqual (terminateIfGteOrNoImprov -5 10 test_deme -1.0 3) True)   ; current(-1.0) == best(-1.0), 3 <= 10, but -1.0 >= -5
+!(assertEqual (terminateIfGteOrNoImprov 10 2 test_deme -1.0 3) True)   ; current(-1.0) == best(-1.0), 3 >= 2
 
 ;; Test best penalized score extraction - exact expected best pen score is -1.0
-!(assertEqual (get-best-penalized-score (getInstanceSet test_deme)) -1.0)
+!(assertEqual (getBestPenalizedScore (getInstanceSet test_deme)) -1.0)
 
 ;; Test with empty deme - best penalized score is worstCscore penalized value
-!(assertEqual (get-best-penalized-score (getInstanceSet (mkDeme (getRep test_deme) (mkSInstSet Nil) 0))) (* -1 (pow-math 10 308)))
+!(assertEqual (getBestPenalizedScore (getInstanceSet (mkDeme (getRep test_deme) (mkSInstSet Nil) 0))) (* -1 (pow-math 10 308)))

--- a/optimization/univariate/test/univariate-tests.metta
+++ b/optimization/univariate/test/univariate-tests.metta
@@ -28,6 +28,7 @@
 !(import! &self metta-moses:deme:score-deme)
 !(import! &self metta-moses:deme:create-deme)
 !(import! &self metta-moses:moses:neighborhood-sampling)
+!(import! &self metta-moses:feature-selection:feature-selection-helpers)
 
 
 ;; ================================================================================
@@ -61,14 +62,14 @@
 ;; ================================================================================
 
 ;; EDA parameters (deterministic)
-!(bind! default_params (default-eda-parameters))
-!(assertEqual (getSelection default_params) 2)
-!(assertEqual (getSelectionRatio default_params) 1.0)
-!(assertEqual (getReplacementRatio default_params) 0.5)
-!(assertEqual (getModelComplexity default_params) 1.0)
+!(bind! DEFAULT_PARAMS (defaultEdaParameters))
+!(assertEqual (getSelection DEFAULT_PARAMS) 2)
+!(assertEqual (getSelectionRatio DEFAULT_PARAMS) 1.0)
+!(assertEqual (getReplacementRatio DEFAULT_PARAMS) 0.5)
+!(assertEqual (getModelComplexity DEFAULT_PARAMS) 1.0)
 
 ;; Information theoretic calculations
-!(assertEqual (disc-spec-multiplicity (mkDiscSpec 3)) 3)
+!(assertEqual (discSpecMultiplicity (mkDiscSpec 3)) 3)
 !(assertEqual (ilog2ceil 1) 0)
 !(assertEqual (ilog2ceil 2) 1)
 !(assertEqual (ilog2ceil 3) 2)
@@ -84,4 +85,4 @@
   (getRep test_deme))
 
 ;; univariate-with-eda with explicit params
-!(assertEqual (let $val (univariate-with-eda test_deme test_ttb test_center (mkEDAParameters 2 1.0 0.5 1.0)) (car-atom $val)) (mkInst (Cons 0 (Cons 0 Nil))))
+!(assertEqual (let $val (univariateEdaLoop test_deme test_ttb test_center (mkEDAParameters 2 1.0 0.5 1.0)) (car-atom $val)) (mkInst (Cons 0 (Cons 0 Nil))))

--- a/optimization/univariate/univariate.metta
+++ b/optimization/univariate/univariate.metta
@@ -12,189 +12,188 @@
 ;; - Uses tournament selection and probability learning
 ;;
 ;; Entry Point: univariate(Deme, TruthTableBScore, Instance) -> (Instance, Deme, State)
+;;
+;; EDA Workflow Integration:
+;; 1. Initialize population with existing instances
+;; 2. Select promising individuals using tournament selection
+;; 3. Learn probability model from selected individuals
+;; 4. Sample new individuals from learned model
+;; 5. Replace worst individuals with new ones
+;; 6. Repeat until termination criteria met
 
 ;; ================================================================================
 ;; Main Univariate Optimization Function
 ;; ================================================================================
 
 ;; Entry point compatible with runMoses/expandDeme (same signature as hillClimbing)
+;; This is the main entry point that sets up EDA parameters and delegates to the EDA-based implementation
 ; (: univariate (-> Deme (TruthTableBScore $a) Instance (Instance Deme $state)))
 (= (univariate $deme $tTableBscorer $centerInst)
   (let* (
-        (() (println! (univariate: $deme $tTableBscorer $centerInst)))
-        ($edaParams (default-eda-parameters))
-        ($result (univariate-with-eda $deme $tTableBscorer $centerInst $edaParams))
+        ;; Entry log (keep concise)
+        (() (println! (univariate: starting)))
+        ($edaParams (defaultEdaParameters))
+        ($result (univariateWithEda $deme $tTableBscorer $centerInst $edaParams))
       )
       $result))
 
-;; Helper to ensure we operate on a concrete Instance value
-; (: unwrap-instance (-> Instance Instance))
-(= (unwrap-instance $inst) $inst)
+;; ================================================================================
+;; EDA-Based Univariate Optimization
+;; ================================================================================
 
 ;; Univariate optimization using EDA framework
-; (: univariate-with-eda (-> Deme (TruthTableBScore $a) Instance (EDAParameters) (Instance Deme $state)))
-(= (univariate-with-eda $deme $tTableBscorer $centerInst $edaParams)
+;; This function sets up the EDA parameters and initializes the population
+;; before entering the main EDA optimization loop
+; (: univariateWithEda (-> Deme (TruthTableBScore $a) Instance (EDAParameters) (Instance Deme $state)))
+(= (univariateWithEda $deme $tTableBscorer $centerInst $edaParams)
   (let* (
-        (() (println! (Starting univariate-with-eda)))
+        (() (println! (univariate-with-eda: start)))
+        ;; Extract scoring parameters
         ((mkTruthTableBScore $cpxCoeff $size $iTable) $tTableBscorer)
-        (() (println! (cpxCoeff: $cpxCoeff size: $size)))
+        
+        ;; Extract deme components
         ((mkDeme $rep (mkSInstSet $instSet) $id) $deme)
         ($discMap (getDiscMap $rep))
         ($discMapLength (MultiMap.length $discMap))
-        (() (println! (discMapLength: $discMapLength)))
+        
+        ;; Calculate population size based on representation complexity
         ($popSize (max 1 $discMapLength))
-        (() (println! (popSize: $popSize)))
+        
         ;; Pre-score population and seed diversity if needed
         ($scoredInit (transform (mkSInstSet $instSet) $rep $iTable $cpxCoeff))
-        (() (println! (scoredInit: $scoredInit)))
         ((mkSInstSet $scoredList) $scoredInit)
-        (() (println! (scoredList: $scoredList)))
+        
+        ;; Add seed instance if population is too small
         ($maybeSeed (if (<= (List.length $scoredList) 1)
-                         (Cons (mkSInst (mkPair (sample-uniform-instance $rep) (worstCscore))) $scoredList)
+                         (Cons (mkSInst (mkPair (sampleUniformInstance $rep) (worstCscore))) $scoredList)
                          $scoredList))
         ($deme0 (mkDeme $rep (mkSInstSet $maybeSeed) $id))
-        (() (println! (deme0: $deme0)))
-        ;; Calculate parameters
+        
+        ;; Calculate EDA parameters
         ($maxGensTotal (min 3 (max 1 $discMapLength)))
-        (() (println! (maxGensTotal: $maxGensTotal)))
         ($maxGensImprov 10)
-        (() (println! (maxGensImprov: $maxGensImprov)))
+        
+        ;; Extract selection and replacement parameters
         ($selection (getSelection $edaParams))
-        (() (println! (selection: $selection)))
         ($selRatio (getSelectionRatio $edaParams))
-        (() (println! (selRatio: $selRatio)))
         ($repRatio (getReplacementRatio $edaParams))
-        (() (println! (repRatio: $repRatio)))
+        
+        ;; Calculate selection and generation counts
         ($nSelect (* $popSize $selRatio))
-        (() (println! (nSelect: $nSelect)))
         ($nGenerate (* $popSize $repRatio))
-        (() (println! (nGenerate: $nGenerate)))
-        (() (println! (maxGensTotal: $maxGensTotal nSelect: $nSelect nGenerate: $nGenerate)))
+        (() (println! (params: popSize= $popSize maxGens= $maxGensTotal nSelect= $nSelect nGenerate= $nGenerate)))
       )
-      (univariate-eda-loop $deme0 $cpxCoeff $iTable $centerInst $edaParams $nSelect $nGenerate 0 $maxGensTotal $maxGensImprov)))
+      ;; Enter the main EDA optimization loop
+      (univariateEdaLoop $deme0 $cpxCoeff $iTable $centerInst $edaParams $nSelect $nGenerate 0 $maxGensTotal $maxGensImprov)))
+
+;; ================================================================================
+;; Main EDA Optimization Loop
+;; ================================================================================
 
 ;; Main EDA loop for univariate optimization
+;; This implements the core EDA workflow: selection → model learning → sampling → replacement
+;; The loop continues until termination criteria are met (max generations reached)
 ; (: univariate-eda-loop (-> Deme Number (ITable $a) Instance (EDAParameters) Number Number Number Number Number (Instance Deme $state)))
-(= (univariate-eda-loop $deme $cpxCoeff $iTable $centerInst $edaParams $nSelect $nGenerate $gen $maxGens $maxGensImprov)
+(= (univariateEdaLoop $deme $cpxCoeff $iTable $centerInst $edaParams $nSelect $nGenerate $gen $maxGens $maxGensImprov)
   (let* (
-        (() (println! (EDA Loop: gen= $gen maxGens= $maxGens)))
+        (() (println! (eda-loop: gen= $gen maxGens= $maxGens)))
         ;; Recompute simple scalar params inside the loop frame to avoid any unevaluated symbols
         ($selection2 (getSelection $edaParams))
       )
+      ;; Check termination condition
       (if (>= $gen $maxGens)
+          ;; Termination: return best result found
           (let* (
-            (() (println! (Reached max generations: $gen)))
-            ($finalCenter (unwrap-instance $centerInst))
-            ($result (make-result $finalCenter $deme))
+            (() (println! (termination: reached max generations)))
+            ($result (makeResult $centerInst $deme))
           )
           $result)
+          ;; Continue optimization: execute EDA workflow
           (let* (
-                (() (println! (Starting EDA step: selection)))
-                ;; Selection step
-                ($selectedInstances (tournament-selection $selection2 $deme $nSelect))
-                (() (println! (Selection done, learning model)))
+                (() (println! (step: selection)))
                 
-                ;; Model learning step
-                ($probModel (learn-probability-model $deme $selectedInstances))
-                (() (println! (Model learning done, sampling)))
+                ;; Step 1: Selection - select promising individuals using tournament selection
+                ($selectedInstances (tournamentSelection $selection2 $deme $nSelect))
+                (() (println! (step: structure-learning)))
                 
-                ;; Sampling step
-                ($newInstances (sample-from-model $probModel $deme $nGenerate))
-                (() (println! (Sampling done, scoring)))
+                ;; Step 2: Structure Learning - explicit no-op for univariate (clarity and parity)
+                (() (univariate-structure-learning $deme $selectedInstances))
+                (() (println! (step: probability-learning)))
                 
-                ;; Scoring step
+                ;; Step 3: Model Learning - learn probability distributions from selected instances
+                ($probModel (learnProbabilityModel $deme $selectedInstances))
+                (() (println! (step: sampling)))
+                
+                ;; Step 4: Sampling - generate new instances from learned probability model
+                ($newInstances (sampleFromModel $probModel $deme $nGenerate))
+                (() (println! (step: scoring)))
+                
+                ;; Step 5: Scoring - evaluate new instances using the scoring function
                 ($scoredNewInstances (transform $newInstances (getRep $deme) $iTable $cpxCoeff))
-                (() (println! (Scoring done, replacing)))
+                (() (println! (step: replacement)))
                 
-                ;; Replacement step
-                ($updatedDeme (replace-the-worst $scoredNewInstances $deme))
-                (() (println! (Replacement done, updating center)))
+                ;; Step 6: Replacement - replace worst instances with new ones
+                ($updatedDeme (replaceTheWorst $scoredNewInstances $deme))
+                (() (println! (step: update-center)))
                 
-                ;; Update center
+                ;; Step 6: Update center - find best instance for next iteration
                 ((mkSInstSet $allInstances) (getInstanceSet $updatedDeme))
-                ($bestSInst (select-best $allInstances))
+                ($bestSInst (selectBest $allInstances))
                 ($nextCenterRaw (getInst $bestSInst))
-                ($nextCenter (unwrap-instance $nextCenterRaw))
-                (() (println! (Center updated, continuing loop)))
+                ($nextCenter $nextCenterRaw)
+                (() (println! (center: updated)))
               )
-              (univariate-eda-loop $updatedDeme $cpxCoeff $iTable $nextCenter $edaParams $nSelect $nGenerate (+ $gen 1) $maxGens $maxGensImprov)))))
+              ;; Recursive call to continue optimization
+              (univariateEdaLoop $updatedDeme $cpxCoeff $iTable $nextCenter $edaParams $nSelect $nGenerate (+ $gen 1) $maxGens $maxGensImprov)))))
+
+;; Convenience wrapper to match test signature: (univariateEdaLoop Deme TruthTableBScore Instance EDAParameters)
+;; Delegates to the full univariate EDA flow with parameter calculation
+(= (univariateEdaLoop $deme $tTableBscorer $centerInst $edaParams)
+  (univariateWithEda $deme $tTableBscorer $centerInst $edaParams))
 
 ;; ================================================================================
 ;; Information Theoretic Calculations
 ;; ================================================================================
 
 ;; Information theoretic bits calculation (from C++ version)
-; (: information-theoretic-bits (-> Representation Number))
-(= (information-theoretic-bits $rep)
+;; This calculates the total number of bits needed to represent all knob values
+;; in the representation, which is used for population sizing
+; (: informationTheoreticBits (-> Representation Number))
+(= (informationTheoreticBits $rep)
    (let* (
          ($discMap (getDiscMap $rep))
          ($specs (MultiMap.values $discMap))
-         ($mults (List.map disc-spec-multiplicity $specs))
+         ($mults (List.map discSpecMultiplicity $specs))
          ($bitsEach (List.map ilog2ceil $mults))
          ($totalBits (List.foldl + 0 $bitsEach))
        )
        (max 1 $totalBits)))
 
 ;; Get multiplicity from DiscSpec
-; (: disc-spec-multiplicity (-> (DiscSpec $knob) Number))
-(= (disc-spec-multiplicity (mkDiscSpec $m)) $m)
+; (: discSpecMultiplicity (-> (DiscSpec $knob) Number))
+(= (discSpecMultiplicity (mkDiscSpec $m)) $m)
 
-;; Integer ceil(log2(n)) without floating math
+;; Ceil(log2(n)) using shared logMath implementation
 ; (: ilog2ceil (-> Number Number))
 (= (ilog2ceil $n)
-   (ilog2ceil-acc $n 1 0))
-
-; (: ilog2ceil-acc (-> Number Number Number Number))
-(= (ilog2ceil-acc $n $v $k)
-   (if (< $v $n)
-       (ilog2ceil-acc $n (* $v 2) (+ $k 1))
-       $k))
+   (let* (
+         ($x (logMath 2 $n))
+         ($f (floor-math $x))
+       )
+       (if (< $f $x) (+ $f 1) $f)))
 
 ;; ================================================================================
 ;; Result Construction
 ;; ================================================================================
 
-;; Make result tuple for compatibility
-(: make-result (-> Instance Deme Expression))
-(= (make-result $inst $deme) ($inst $deme ()))
+;; Make result tuple for compatibility with runMoses/expandDeme interface
+;; Returns a tuple of (Instance, Deme, State) where State is empty
+(: makeResult (-> Instance Deme Expression))
+(= (makeResult $inst $deme) ($inst $deme ()))
 
 ;; ================================================================================
-;; Legacy Simple Implementation (for comparison)
+;; Helper Functions
 ;; ================================================================================
 
-;; Simple univariate function without EDA (kept for backward compatibility)
-; (: univariate-simple (-> Deme (TruthTableBScore $a) Instance (Instance Deme $state)))
-(= (univariate-simple $deme $tTableBscorer $centerInst)
-   (let* (
-         ((mkTruthTableBScore $cpxCoeff $size $iTable) $tTableBscorer)
-         ((mkDeme $rep (mkSInstSet $instSet) $id) $deme)
-         ($discMap (getDiscMap $rep))
-         ($discMapLength (MultiMap.length $discMap))
-         ($maxGens (max 1 $discMapLength))
-       )
-       (univariate-simple-loop $deme $cpxCoeff $iTable $centerInst 0 $maxGens)))
-
-;; Simple loop without EDA
-; (: univariate-simple-loop (-> Deme Number (ITable $a) Instance Number Number (Instance Deme $state)))
-(= (univariate-simple-loop (mkDeme $rep (mkSInstSet $instSet) $id)
-                    $cpxCoeff $iTable $centerInst $gen $maxGens)
-   (if (>= $gen $maxGens)
-       (let* (
-         ($result ($centerInst (mkDeme $rep (mkSInstSet $instSet) $id) ()))
-       )
-       $result)
-       (let* (
-             ;; Simple neighborhood sampling
-             ($totalNeighbors (estimateNeighborhood 1 (getDiscMap $rep)))
-             ($nNew (min $totalNeighbors 3))
-             (($demeWithNewInsts $added) (sampleNewInstances $totalNeighbors $nNew $centerInst (mkDeme $rep (mkSInstSet $instSet) $id) 1))
-             ((mkSInstSet $scored) (transform (getInstanceSet $demeWithNewInsts) (getRep $demeWithNewInsts) $iTable $cpxCoeff))
-             ($demeScored (mkDeme (getRep $demeWithNewInsts) (mkSInstSet $scored) (getDemeId $demeWithNewInsts)))
-             ((mkSInst $bestPair) (List.foldl ((curry2 returnBest) <) (mkSInst (mkPair $centerInst (worstCscore))) $scored))
-             ($nextCenter (Pair.first $bestPair))
-           )
-           (univariate-simple-loop $demeScored $cpxCoeff $iTable $nextCenter (+ $gen 1) $maxGens))))
-
-;; Helper function to get deme ID
 ; (: getDemeId (-> Deme DemeId))
 (= (getDemeId (mkDeme $rep $instSet $id)) $id)


### PR DESCRIPTION
### <!--- Provide a general summary of your changes in the Title above -->


## Description
- Removed unnecessary debug prints across EDA modules to reduce noise.
- Consolidated repeated logic using higher-order functions (e.g., `List.foldl`) where appropriate.
- Deleted unused/duplicated helper functions.
- Renamed identifiers to camelCase to match repository conventions.
- Minor tidy-ups in tests to reflect the refactors and imports.

These changes build on and further streamline the helper-function organization and cleanup introduced in the last PR, maintaining the same intent while reducing complexity and improving readability. See prior context in [PR #341](https://github.com/iCog-Labs-Dev/metta-moses/pull/341).

## Motivation and Context
- Improve maintainability by reducing duplication and ad-hoc helper functions.
- Improve readability and consistency by standardizing identifier naming to camelCase.
- Reduce console noise and make test signal clearer by removing debug prints.
- Aligns with the cleanup and organization direction from [PR #341](https://github.com/iCog-Labs-Dev/metta-moses/pull/341).

## How Has This Been Tested?
- Ran the test suite via `scripts/run-tests.py`; all tests pass locally.
- Updated tests where needed to reflect naming and helper consolidation.
- Verified no functional regressions in EDA flow (initialization → selection → probability learning → sampling → replacement → termination) and univariate loop.
- Checked for linter issues; none introduced.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added/updated tests to cover my changes where necessary.
- [x] All new and existing tests passed.