### PR TITLE
fix(reduct): align contradiction and tautology handling with classic MOSES

### DIFF
--- a/deme/tests/merge-demes-test.metta
+++ b/deme/tests/merge-demes-test.metta
@@ -308,6 +308,7 @@
 ;;  Testcase-1 for demeToTrees
 ;;  NOTE: All the instances in the deme don't include lsk1 (or they all start with '0') because we are testing it using ttable2. 
 ;;        ttable2 is a truth table which doesn't have a 'D' column.
+;;  Instance (0 1 2) reduces to a contradiction, so its tree is the empty OR (false).
 !(assertEqual
   (demeToTrees (mkDeme (mkRep (mkKbMap 
                                   (mkDscKbMp (cons ((mkNodeId (2 3)) 0) (cons ((mkNodeId (3)) 1) (cons ((mkNodeId (1)) 2) ())))) 
@@ -321,7 +322,7 @@
                           (mkSInstSet (cons (mkSInst (mkPair (mkInst (cons 0 (cons 0 (cons 1 ())))) (mkCscore -1 2 1 0 1))) 
                                       (cons (mkSInst (mkPair (mkInst (cons 0 (cons 1 (cons 2 ())))) (mkCscore 0 2 0.5 0 0.8))) ()))) (mkDemeId "1")) (ttable2))
 
-  (cons (mkExemplar (mkTree (mkNode AND) (cons (mkTree (mkNode A) ()) (cons (mkTree (mkNode OR) (cons (mkTree (mkNode B) ()) (cons (mkTree (mkNode C) ()) ()))) ()))) (mkDemeId "1") (mkCscore -1 2 1 0 1) (mkBScore (cons 0 (cons 0 (cons 0 (cons 0 ())))))) (cons (mkExemplar (mkTree (mkNode AND) ()) (mkDemeId "1") (mkCscore 0 2 0.5 0 0.8) (mkBScore (cons -1 (cons -1 (cons -1 (cons -1 ())))))) ())))
+  (cons (mkExemplar (mkTree (mkNode AND) (cons (mkTree (mkNode A) ()) (cons (mkTree (mkNode OR) (cons (mkTree (mkNode B) ()) (cons (mkTree (mkNode C) ()) ()))) ()))) (mkDemeId "1") (mkCscore -1 2 1 0 1) (mkBScore (cons 0 (cons 0 (cons 0 (cons 0 ())))))) (cons (mkExemplar (mkTree (mkNode OR) ()) (mkDemeId "1") (mkCscore 0 2 0.5 0 0.8) (mkBScore (cons -1 (cons 0 (cons 0 (cons 0 ())))))) ())))
 
 ;; Testcase-2 for demeToTrees
 !(assertEqual 

--- a/deme/tests/score-deme-test.metta
+++ b/deme/tests/score-deme-test.metta
@@ -116,7 +116,8 @@
       (cons (mkInst (cons 0 (cons 1 (cons 2 ())))) (cons (mkInst (cons 0 (cons 2 (cons 1 ())))) ()))
       (ttable2)
       2.0)
-      (cons (mkSInst (mkPair (mkInst (cons 0 (cons 1 (cons 2 ())))) (mkCscore -4 0 0.0 0.0 -4.0))) (cons (mkSInst (mkPair (mkInst (cons 0 (cons 2 (cons 1 ())))) (mkCscore -4 0 0.0 0.0 -4.0))) ())))
+      ;; both instances reduce to constant false, wrong on ttable2's first output row only
+      (cons (mkSInst (mkPair (mkInst (cons 0 (cons 1 (cons 2 ())))) (mkCscore -1 0 0.0 0.0 -1.0))) (cons (mkSInst (mkPair (mkInst (cons 0 (cons 2 (cons 1 ())))) (mkCscore -1 0 0.0 0.0 -1.0))) ())))
 
 ;; Testcases for transform
 !(assertEqual
@@ -137,7 +138,8 @@
    (mkDemeId "1")
    (ttable2)
    1)
-   (mkSInstSet (cons (mkSInst (mkPair (mkInst (cons 0 (cons 1 (cons 2 ())))) (mkCscore -4 0 0.0 0.0 -4.0))) (cons (mkSInst (mkPair (mkInst (cons 0 (cons 1 (cons 1 ())))) (mkCscore 0 3 3.0 0.0 -3.0))) ()))))
+   ;; (0 1 2) is the same constant-false candidate scored above
+   (mkSInstSet (cons (mkSInst (mkPair (mkInst (cons 0 (cons 1 (cons 2 ())))) (mkCscore -1 0 0.0 0.0 -1.0))) (cons (mkSInst (mkPair (mkInst (cons 0 (cons 1 (cons 1 ())))) (mkCscore 0 3 3.0 0.0 -3.0))) ()))))
 
 ;; Testcase for the bitsToIndices
 !(assertEqual (bitsToIndices (cons 1 (cons 0 (cons 1 (cons 0 ())))) 0 ()) (0 2))

--- a/reduct/boolean-reduct/delete-inconsistent-handle.metta
+++ b/reduct/boolean-reduct/delete-inconsistent-handle.metta
@@ -7,7 +7,9 @@
 ;;                and its negagtion.
 ;; Preconditions: The point of application (POA) is AND node and
 ;;                its handle set is inconsistent.
-;; Action: The function removes the POA and updates the parent.
+;; Action: The POA is false. An OR parent simply drops it, false being the
+;;            OR-identity; an AND parent (and the root) collapses to the empty
+;;            OR instead, since false annihilates a conjunction.
 ;;            It then returns the updated parent, an empty expression and
 ;;            a boolean value of True if applied.
 ;; Example: input: POA ==> (AND (NOT A) (OR B C)), dominantSet ==> (A), parent ==> (OR B (AND (NOT A) (OR B C)))
@@ -19,16 +21,21 @@
           ($guardSet     (getGuardSet $current))
           ($handleSet    (concatTuple $dominantSet $guardSet))
           ($isConsistent (isConsistentExp $handleSet))
+          ($parentHead   (if (and (!= $parent ()) (== (get-metatype $parent) Expression)) (car-atom $parent) ()))
+          ($withoutPOA   (subtraction-atom $parent ($current)))
+          ;; the applyDeleteIncons* walkers can pass a sibling as $parent, where
+          ;; removing the POA is a no-op -- only a real conjunct can be annihilated
+          ($isConjunct   (and (== $parentHead AND) (!= $withoutPOA $parent)))
           ; ($_ (println! (===Inside DeleteInconsistentHandle===)))
           ; ($_ (println! (Parameters ==> Parent: $parent Current: $current DominantSet: $dominantSet)))
           ; ($_ (println! (GuardSet : $guardSet : HandleSet : $handleSet : IsConsistent : $isConsistent)))
         )
         (if $isConsistent
               ($parent $current False)
-              (if (== $parent $current) ;; If the initial parent itself is in consistent, we don't want to delete it entirely but instead keep a top level AND. This only happens when passing the expression for the first time as $parent and $current will never be equal after that.
-                  ((AND) () True)
-                  ((subtraction-atom $parent ($current)) () True)
-              )) ;; Remove current from parent and return an empty AND.
+              (if (or (== $parent $current) $isConjunct)
+                  ((OR) () True)
+                  ($withoutPOA () True)
+              ))
     )
 )
 

--- a/reduct/boolean-reduct/promote-common-constraints.metta
+++ b/reduct/boolean-reduct/promote-common-constraints.metta
@@ -11,6 +11,8 @@
 ;;              parent of the POA and the updated parent, the updated
 ;;              POA and a boolean indicator whether the transformation
 ;;              is applied or not are returned in a tuple.
+;;            A branch the subtraction empties is the empty conjunction, i.e.
+;;              true, so the POA is a tautology and is dropped from the parent.
 ;; Example: input: POA ==> (OR (AND (NOT B) C) (NOT B)), parent ==> (AND A (OR (AND (NOT B) C) (NOT B)) (OR (NOT C) (AND (NOT B) (NOT D))))
 ;;        : output: ((AND A (NOT B) (OR (AND C) (AND)) (OR (NOT C) (AND (NOT B) (NOG D)))) () True)
 ;(: promoteCommonConstraints (-> Expression Expression (Expression Expression Bool)))
@@ -32,13 +34,30 @@
                       ;; (() (println! (Removing Common Literals: $common)))
                       ($updatedChildren (removeCommonLiterals $common $children))
                       ($updatedLiterals (removeElement $common $literals))
-                      ($newExp (concatTuple $updatedLiterals $updatedChildren ))
-
-                      ($newCurrent (cons-atom OR $newExp))
-                      ($updatedParent (findAndReplace $current $newCurrent $parent))
-                      ($updatedParent' (addLiterals $updatedParent $common))
+                      ;; A branch emptied by the promotion is true, and so is the POA.
+                      ;; Guarded on every branch being a sub-expression: findCommon reads
+                      ;; only those branches' guard sets, so with a bare literal branch
+                      ;; alongside them an empty (AND) proves nothing.
+                      ($currentHead (if (== (get-metatype $current) Expression) (car-atom $current) ()))
+                      ($isTautology (and (and (== $currentHead OR) (== $literals ()))
+                                         (any (map-atom $updatedChildren $b (== $b (AND))))))
                     )
-                    ($updatedParent' $newCurrent True)
+                    (if $isTautology
+                        ;; true is the AND-identity: the POA leaves, the promoted literals stay
+                        (if (== $parent $current)
+                            ((AND) () True)
+                            ((addLiterals (removeElement ($current) $parent) $common) () True))
+                        (let*
+                            (
+                              ($newExp (concatTuple $updatedLiterals $updatedChildren ))
+
+                              ($newCurrent (cons-atom OR $newExp))
+                              ($updatedParent (findAndReplace $current $newCurrent $parent))
+                              ($updatedParent' (addLiterals $updatedParent $common))
+                            )
+                            ($updatedParent' $newCurrent True)
+                        )
+                    )
                 )
             )
         )

--- a/reduct/boolean-reduct/reduce-to-elegance.metta
+++ b/reduct/boolean-reduct/reduce-to-elegance.metta
@@ -435,6 +435,11 @@
 ;; (= (reduce $expr) (let ($parent $__ $applied) (reduceToElegance $expr $expr () ()) (trace! (Result: ($parent $__ $applied)) (if $applied (reduce $parent) $parent))))
 ; (: applyReduce (-> (Expression Expression Bool) (Expression Expression Bool)))
 (= (applyReduce ($parent $current $applied))
+   ;; The empty OR is false and already elegant. Re-normalising it lets addAND
+   ;; rebuild (AND (OR)), where the dangling-junctor cleanup deletes the false as
+   ;; if it were one of the empty placeholders that arrive from knob building.
+   (if (== $current (OR))
+       ((OR) (OR) False)
    (let*
          (
             ;; ($_ (println! (==== Inside ApplyReduce ====)))
@@ -454,7 +459,7 @@
            ;; ($_ (println! (FinalParent: $finalParent)))
         )
          (reduceToElegance $finalParent $finalAdd () ())
-         ))
+         )))
 
 (= (removeAndNodesFromGuards $expr)
    (if (== (get-metatype $expr) Symbol)

--- a/reduct/boolean-reduct/tests/delete-inconsistent-test.metta
+++ b/reduct/boolean-reduct/tests/delete-inconsistent-test.metta
@@ -8,8 +8,9 @@
 !(assertEqual (deleteInconsistentHandle (AND) () ()) ((AND) () False))
 !(assertEqual (deleteInconsistentHandle (AND (A)) (A) (B C)) ((AND (A)) (A) False))
 !(assertEqual (deleteInconsistentHandle (AND (A)) (A) (B C)) ((AND (A)) (A) False))
-!(assertEqual (deleteInconsistentHandle (AND (A)) (A) ((NOT A) B C)) ((AND) () True)) ;; replaces A with AND
-!(assertEqual (deleteInconsistentHandle (AND (A)) (A) (B C (NOT A))) ((AND) () True)) ;; 
+;; false under an AND parent annihilates it, so the parent becomes the empty OR
+!(assertEqual (deleteInconsistentHandle (AND (A)) (A) ((NOT A) B C)) ((OR) () True))
+!(assertEqual (deleteInconsistentHandle (AND (A)) (A) (B C (NOT A))) ((OR) () True))
 !(assertEqual (deleteInconsistentHandle (AND A) A (B C)) ((AND A) A False))
 
 ;; Test 02 - for OR and NOT expressions

--- a/reduct/boolean-reduct/tests/promote-common-constraint-test.metta
+++ b/reduct/boolean-reduct/tests/promote-common-constraint-test.metta
@@ -39,9 +39,10 @@
 )
 
 ;; Test 07: Test case from Holman paper page #39
+;; promoting (NOT B) empties the second branch, so the POA is true and leaves the parent
 !(assertEqual
     (promoteCommonConstraints (AND A (OR (AND (NOT B) C) (AND (NOT B))) (OR (AND (NOT C)) (AND (NOT B) (NOT D)))) (OR (AND (NOT B) C) (AND (NOT B))))
-    ((AND A (NOT B) (OR (AND C) (AND)) (OR (AND (NOT C)) (AND (NOT B) (NOT D)))) (OR (AND C) (AND)) True)
+    ((AND A (NOT B) (OR (AND (NOT C)) (AND (NOT B) (NOT D)))) () True)
 )
 
 ;;remove element Test

--- a/reduct/boolean-reduct/tests/rte2-test.metta
+++ b/reduct/boolean-reduct/tests/rte2-test.metta
@@ -43,7 +43,7 @@
 !(assertEqual (reduceToElegance (AND A (OR (AND B) (AND (NOT A) (OR (AND B) (AND C))))) (OR (AND B) (AND (NOT A) (OR (AND B) (AND C)))) (A) (B)) ((AND A ) () True))
 
 ;; Promote Common Constraints Test
-!(assertEqual (reduceToElegance (AND A (OR (AND (NOT B) C) (AND (NOT B))) (OR (AND (NOT C)) (AND (NOT B) (NOT D)))) (OR (AND (NOT B) C) (AND (NOT B))) (A) ()) ((AND A (NOT B) (OR (AND (NOT C)) (AND (NOT B) (NOT D))) C) () True)) ;; FIX: Classic says this should be (AND)
+!(assertEqual (reduceToElegance (AND A (OR (AND (NOT B) C) (AND (NOT B))) (OR (AND (NOT C)) (AND (NOT B) (NOT D)))) (OR (AND (NOT B) C) (AND (NOT B))) (A) ()) ((AND A (NOT B) (OR (AND (NOT C)) (AND (NOT B) (NOT D)))) () True)) ;; INFO: classic reduces this POA, or(and(!$2 $3) and(!$2)), to !$2 -- so C must not be promoted
 ;; Python's reduct says it should be (AND A (OR (AND (NOT B) C) (AND (NOT B))))
 
 ;; Subtract Redundant Test

--- a/reduct/boolean-reduct/tests/rte4-test.metta
+++ b/reduct/boolean-reduct/tests/rte4-test.metta
@@ -9,8 +9,8 @@
 !(import! &self ../reduce-to-elegance)
 
 
-;; (AND A B C D (NOT B)) ==> (AND)
-!(assertEqual (reduceToElegance (AND (AND A B C D (NOT B))) (AND A B C D (NOT B)) () ()) ((AND) (AND) False))
+;; (AND A B C D (NOT B)) ==> (OR)
+!(assertEqual (reduceToElegance (AND (AND A B C D (NOT B))) (AND A B C D (NOT B)) () ()) ((OR) (AND) False))
 ;; (AND B (NOT C) (NOT A) (OR B (NOT A))) ==> (AND B (NOT C) (NOT A))
 !(assertEqual (reduceToElegance (AND (AND B (NOT C) (NOT A) (OR B (NOT A)))) (AND B (NOT C) (NOT A) (OR B (NOT A))) () ()) ((AND (AND B (NOT C) (NOT A) (OR B (NOT A)))) (AND B (NOT C) (NOT A) (OR B (NOT A))) False))
 ;; (AND B (NOT C) (NOT A) (OR B (AND (NOT K) (NOT X)))) ==> (AND B (NOT C) (NOT A))
@@ -19,8 +19,8 @@
 !(assertEqual (reduceToElegance (AND (AND (NOT A) (NOT C) B (OR (AND (NOT B)) (AND (NOT A))))) (AND (NOT A) (NOT C) B (OR (AND (NOT B)) (AND (NOT A)))) () ()) ((AND (AND (NOT A) (NOT C) B)) (AND (NOT A) (NOT C) B) False))
 ;; (AND B (NOT C) (NOT A) (OR (NOT B) (NOT C) (NOT D) (NOT A))) ==> (AND B (NOT C) (NOT A))
 !(assertEqual (reduceToElegance (AND (AND B (NOT C) (NOT A) (OR (NOT B) (NOT C) (NOT D) (NOT A)))) (AND B (NOT C) (NOT A) (OR (NOT B) (NOT C) (NOT D) (NOT A))) () ()) ((AND (AND B (NOT C) (NOT A) (OR (NOT B) (NOT C) (NOT D) (NOT A)))) (AND B (NOT C) (NOT A) (OR (NOT B) (NOT C) (NOT D) (NOT A))) False))
-;; (AND A B C B A A (NOT A) (OR A B C A)) ==> (AND)
-!(assertEqual (reduceToElegance (AND (AND A B C B A A (NOT A) (OR A B C A))) (AND A B C B A A (NOT A) (OR A B C A)) () ()) ((AND) (AND) False))
+;; (AND A B C B A A (NOT A) (OR A B C A)) ==> (OR)
+!(assertEqual (reduceToElegance (AND (AND A B C B A A (NOT A) (OR A B C A))) (AND A B C B A A (NOT A) (OR A B C A)) () ()) ((OR) (AND) False))
 ;; (AND (OR A B)) ==> (AND (OR A B))
 !(assertEqual (reduceToElegance (AND (OR A B)) (OR A B) () ()) ((AND (OR A B)) (OR A B) False))
 ;; (AND (OR A A)) ==> (AND A)

--- a/reduct/boolean-reduct/tests/rte6-test.metta
+++ b/reduct/boolean-reduct/tests/rte6-test.metta
@@ -15,6 +15,7 @@
 ;; (AND (OR (NOT A) (AND A B C) (AND C B (NOT B)))) ==> (AND (OR (NOT A ) (AND A B C)))
 !(assertEqual (reduceToElegance (AND (OR (NOT A) (AND A B C) (AND C B (NOT B)))) (OR (NOT A) (AND A B C) (AND C B (NOT B))) () ()) ((AND B C (OR (NOT A) (AND A) (AND (NOT B)))) (OR (NOT A) (AND A) (AND (NOT B))) True))
 ;; (AND (OR (AND C A D) (AND C A) (AND C A E))) ==> (AND C A)
-!(assertEqual (reduceToElegance (AND (OR (AND C A D) (AND C A) (AND C A E))) (OR (AND C A D) (AND C A) (AND C A E)) () ()) ((AND C A (OR (AND D) (AND E))) (OR (AND D) (AND E)) true)) ;; FIX: Classic says this should be: (AND (OR (AND D E) A) C)
+!(assertEqual (reduceToElegance (AND (OR (AND C A D) (AND C A) (AND C A E))) (OR (AND C A D) (AND C A) (AND C A E)) () ()) ((AND C A) () true)) ;; INFO: classic reduces this POA to and($1 $3) -- the (AND C A) branch subsumes the other two
+;; The old FIX note here read (AND (OR (AND D E) A) C), which is classic's answer for a different tree: or(and($3 $1) and($3 $4 $5))
 ;; (AND (OR (AND A B) (AND A C D) (AND A C E) (AND C A))) ==> (AND A (OR B (AND C D) (AND C E) C))
 !(assertEqual (reduceToElegance (AND (OR (AND A B) (AND A C D) (AND A C E) (AND C A))) (OR (AND A B) (AND A C D) (AND A C E) (AND C A)) () ()) ((AND A (OR (AND B) (AND C D) (AND C E) (AND C))) (OR (AND B) (AND C D) (AND C E) (AND C)) True))

--- a/reduct/boolean-reduct/tests/rte7-test.metta
+++ b/reduct/boolean-reduct/tests/rte7-test.metta
@@ -13,13 +13,13 @@
 ;; Test 04: Test case from Mosh's paper. Page 37
 
 ;; (AND (OR G (AND A B (OR (NOT C) (NOT D) E) (OR C (AND C F))))) ==> (AND (OR G (AND A B C (OR (NOT D) E))))
-!(assertEqual (reduceToElegance (AND (OR (AND G) (AND A B (OR (AND (NOT C)) (AND (NOT D)) (AND E)) (OR (AND C) (AND C F))))) (OR (AND G) (AND A B (OR (AND (NOT C)) (AND (NOT D)) (AND E)) (OR (AND C) (AND C F)))) () ()) ((AND (OR (AND G) (AND A B C (OR (AND (NOT D)) (AND E)) F))) (OR (AND G) (AND A B C (OR (AND (NOT D)) (AND E)) F)) false)) ;; INFO: Tested against classic and this is the result of the reduct
+!(assertEqual (reduceToElegance (AND (OR (AND G) (AND A B (OR (AND (NOT C)) (AND (NOT D)) (AND E)) (OR (AND C) (AND C F))))) (OR (AND G) (AND A B (OR (AND (NOT C)) (AND (NOT D)) (AND E)) (OR (AND C) (AND C F)))) () ()) ((AND (OR (AND G) (AND A B C (OR (AND (NOT D)) (AND E))))) (OR (AND G) (AND A B C (OR (AND (NOT D)) (AND E)))) false)) ;; INFO: Tested against classic and this is the result of the reduct
 ;; (AND (OR G (AND A B C (OR (NOT D) E)))) ==> (AND (OR G (AND A B C (OR (NOT D) E))))
 !(assertEqual (reduceToElegance (AND (OR (AND G) (AND A B C (OR (AND (NOT D)) (AND E))))) (OR (AND G) (AND A B C (OR (AND (NOT D)) (AND E)))) () ()) ((AND (OR (AND G) (AND A B C (OR (AND (NOT D)) (AND E))))) (OR (AND G) (AND A B C (OR (AND (NOT D)) (AND E)))) False))
 !(assertEqual (reduceToElegance (AND E (OR (AND A) (AND B) (AND C D))) (OR (AND A) (AND B) (AND C D)) () ()) ((AND E (OR (AND A) (AND B) (AND C D))) (OR (AND A) (AND B) (AND C D)) False))
 !(assertEqual (reduceToElegance (OR (AND A) (AND B) (AND C D)) (AND C D) () ()) ((OR (AND A) (AND B) (AND C D)) (AND C D) False))
 
-!(assertEqual (reduce-to (AND (OR (AND G) (AND A B (OR (AND (NOT C)) (AND (NOT D)) (AND E)) (OR (AND C) (AND C F)))))) (AND (OR G (AND A B C F (OR (NOT D) E))))) ;; INFO: Tested against classic and this is the result.
+!(assertEqual (reduce-to (AND (OR (AND G) (AND A B (OR (AND (NOT C)) (AND (NOT D)) (AND E)) (OR (AND C) (AND C F)))))) (AND (OR G (AND A B C (OR (NOT D) E))))) ;; INFO: Tested against classic and this is the result.
 !(assertEqual (reduce-to (AND (OR A B) A)) A)
 
 !(assertEqual (reduce-to (AND (OR (AND (OR)) (AND (OR (AND (NOT X1))))))) (NOT X1))

--- a/utilities/tests/tree-test.metta
+++ b/utilities/tests/tree-test.metta
@@ -84,7 +84,7 @@
                       (cons (mkTree (mkNode NOT) (cons (mkTree (mkNode A) ()) ()))
                       (cons (mkTree (mkNode B) ()) ()))))
 !(assertEqual (cleanTree (buildTree (AND (OR A B) (NOT A) (NOT B)))) (buildTree (AND (NOT A) (NOT B))))
-!(assertEqual (cleanTree (buildTree (AND A B (NOT A)))) (buildTree (AND)))
+!(assertEqual (cleanTree (buildTree (AND A B (NOT A)))) (buildTree (OR))) ;; a contradiction is false, i.e. the empty OR
 !(assertEqual (cleanTree (buildTree (OR (AND A B (NOT A) B)))) (buildTree (AND)))
 !(assertEqual (cleanTree (buildTree (OR A (AND B C)))) (buildTree (AND (OR A (AND B C)))))
 !(assertEqual (cleanTree (buildTree (OR A B C D))) (buildTree (AND (OR A B C D))))


### PR DESCRIPTION
## Description

The three reduct cases flagged in #486 disagreed with classic MOSES because of a single missing distinction, in two places.

Classic's ENF pass is three-valued: `reduce()` returns `Delete` (this subtree is **false**), `Disconnect` (this subtree is **true**), or `Keep`, and the parent acts on that verdict *according to its own junctor* (`logical_rules.h:181`, `logical_rules.cc:462-467`, `715`, `817-825`). Our RTE has no such verdict — every transformation returns `($parent $current $applied)` and encodes both verdicts identically: **unlink the node from its parent**. That is correct in exactly two of the four cases and inverted in the other two:

| child verdict | correct under AND parent | correct under OR parent |
|---|---|---|
| **false** | whole AND → false | drop the child |
| **true** | drop the child | whole OR → true |

We always dropped the child, so the annihilator cells came out backwards. Verified end-to-end before the fix:

```
(reduce-to (AND (AND A (NOT A)) B))      => (AND)   ✗ should be false   ← RTE4-01/06
(reduce-to (AND (OR (AND) (AND B))))     => B       ✗ should be true    ← RTE7-05
(reduce-to (OR (AND A (NOT A)) (AND B))) => B       ✓
(reduce-to (AND A (AND)))                => A       ✓
```

**Fix 1 — false propagation** (`delete-inconsistent-handle.metta`, `reduce-to-elegance.metta`). An inconsistent handle makes the POA false. An OR parent still just drops it; an AND parent (and the root) now collapses to the empty `OR`. `applyReduce` short-circuits on that empty `OR` so it survives — otherwise `addAND` rebuilds `(AND (OR))` and the dangling-junctor cleanup eats it.

**Fix 2 — true propagation** (`promote-common-constraints.metta`). When promoting the common literals consumes a branch whole, that branch is the empty conjunction (true), so the POA is a tautology and leaves its AND parent — keeping the literals just promoted in. Previously the empty `(AND)` was left for the cleanup to delete, which kept the *other* branches' literals instead. That's where the stray `F` came from.

Results now match classic exactly:

| Case | classic | before | after |
|---|---|---|---|
| RTE4-01 `and($1 $2 $3 $4 !$2)` | `false` | `(AND)` | `(OR)` |
| RTE4-06 `and($1 $2 $3 $2 $1 $1 !$1 or(…))` | `false` | `(AND)` | `(OR)` |
| RTE7-05 `or($7 and($1 $2 or(!$3 !$4 $5) or($3 and($3 $6))))` | `or(and(or(!$4 $5) $1 $2 $3) $7)` | keeps `F` | `(AND (OR G (AND A B C (OR (NOT D) E))))` |

## Motivation and Context

Fixes #486 (test-case differences catalogued under #473).

Beyond the three cases: `reduce-to` is live at `cleanTree`, so a contradictory candidate used to reach the scorer as constant **true** rather than **false**, and `or(X and(X Y))` used to be strengthened to `X ∧ Y`. Both make the search optimise against a formula that isn't the candidate.

### Design decisions
**Fix at the creation site, not globally.** `(AND)`/`(OR)` are overloaded in this pipeline: inside the ENF pass an emptied junctor is a real constant, but in the *input* tree it is a dangling knob-building placeholder that must be deleted — classic makes the same distinction, temporally, by running `eval_logical_identities` / `remove_dangling_junctors` as a pre-pass before `subtree_to_enf`. So the constant reading is applied only where the fix itself creates the empty junctor and can be sure it's real. `zeroConstraintSubsume` and `removeEmptyAND` keep deleting placeholders, and rte7's `(OR (AND (OR (AND D0 Addr))) (AND))` family still reduces to `(AND D0 Addr)`.

Two guards fell out of that and both earn their keep — the first drafts without them regressed rte3 and rte5:

- The AND collapse is conditional on the POA really being a conjunct of the parent. The `applyDeleteIncons*` walkers sometimes pass a *sibling* in the parent slot, where unlinking was a no-op but collapsing destroyed the sibling (rte5 case 5).
- The tautology conclusion is restricted to POAs whose branches are all sub-expressions. `findCommon` reads only those branches' guard sets, so with a bare-literal branch present the common set was never checked against it and an empty `(AND)` proves nothing (rte3 case 6).

## How Has This Been Tested?

- **Differential against classic.** Built `test_reduct` from `OpenCog/Moses` and compared every case at reduction efforts 1, 2 and 3 (identical at all three, so the classic answer is not an artifact of the truth-table pruning pass). Confirmed the three failures, then confirmed the fixed output matches classic term for term, plus minimal repros: `or(and($3) and($3 $6))` → `$3`, `and(and($1 !$1) $2)` → `false`.
- **Full suite, before and after.** All 85 of the repo's own `*test.metta` files (excluding the `.claude/worktrees` checkouts), run against a pristine worktree at `dev` for the baseline. Baseline **85/85**; after this branch **85/85**.
- **Unmasked every affected file.** A failing `assertEqual` halts the run, so each blocker was commented out in a scratch copy and the file re-run until green. That is how RTE7-05 was seen passing — it had never executed, since the file halts at case 1 — and how the second `score-deme-test` case was found hiding behind the first.
- **Every changed expectation justified individually**, either differentially against classic or recomputed by hand. For the two scoring tests: `ttable2`'s output column is `(True False False False)`, so a constant-false candidate is wrong on the first row only — the old `(-1 -1 -1 -1)` and `-4` were not reachable by *any* constant, so those expectations were already inconsistent before this change.
- Each commit was verified green in isolation, so the history bisects.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

`reduce-to` can now return the empty `OR` (false), which it never did before. Consumers that assumed a reduced tree is always AND-rooted should be checked — `cleanTree`/`buildTree` handle it (covered by `tree-test`), and the scorer evaluates it correctly (covered by the two deme tests).

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
