### PR TITLE
Fix: sampling semantics

### DIFF
--- a/moses/neighborhood-sampling.metta
+++ b/moses/neighborhood-sampling.metta
@@ -43,20 +43,58 @@
    (cons (effectiveSpecValues (getKnobMultip $knob))
          (discEffectiveSpecLists (mkDscMp $tail))))
 
-(= (varyNKnobsBySpecLists $specLists $instExp $dist)
-   (varyNKnobsBySpecLists $specLists $instExp $dist 0))
-(= (varyNKnobsBySpecLists $specLists $instExp $dist $startI)
+;; Previous implementation: generated instances at all distances 1..dist.
+;; Preserved for reference; renamed to avoid confusion with the corrected version.
+(= (varyNKnobsBySpecListsAllDistances $specLists $instExp $dist)
+   (varyNKnobsBySpecListsAllDistances $specLists $instExp $dist 0))
+(= (varyNKnobsBySpecListsAllDistances $specLists $instExp $dist $startI)
    (if (or (== $dist 0) (== $startI (length $instExp)))
        ()
        (let*
          (
            ($specs (List.getByIdx $specLists $startI))
            ($changeIs (map-atom $specs $m (changeAt $m $startI $instExp)))
-           ($changeRest (varyNKnobsBySpecLists $specLists $instExp $dist (+ $startI 1)))
-           ($changeDs (map-atom $changeIs $changeI (varyNKnobsBySpecLists $specLists $changeI (- $dist 1) (+ $startI 1))))
+           ($changeRest (varyNKnobsBySpecListsAllDistances $specLists $instExp $dist (+ $startI 1)))
+           ($changeDs (map-atom $changeIs $changeI (varyNKnobsBySpecListsAllDistances $specLists $changeI (- $dist 1) (+ $startI 1))))
            ($flatDs (foldl-atom $changeDs () $acc $changeD (append $changeD $acc)))
            ($acc (append $changeIs $changeRest))
            ($final (append $acc $flatDs))
+         )
+         (filter-atom $final isNotUnit))))
+
+;; Corrected implementation matching C++ vary_n_knobs semantics for spec lists.
+;; Same fix as varyNKnobs: returns the instance at dist == 0, dead end at
+;; startI >= length, and omits single-position $changeIs from the output.
+(= (varyNKnobsBySpecLists $specLists $instExp $dist)
+   (varyNKnobsBySpecLists $specLists $instExp $dist 0))
+(= (varyNKnobsBySpecLists $specLists $instExp $dist $startI)
+   (case ($dist (>= $startI (length $instExp)))
+     (
+       ((0 $_) ($instExp))
+       ((1 $_) (varyNKnobsBySpecListsDist1 $specLists $instExp $startI))
+       (($dist True) ())
+       (($dist False)
+        (let*
+          (
+            ($specs (List.getByIdx $specLists $startI))
+            ($changeRest (varyNKnobsBySpecLists $specLists $instExp $dist (+ $startI 1)))
+            ($changeDs (map-atom $specs $m (varyNKnobsBySpecLists $specLists (changeAt $m $startI $instExp) (- $dist 1) (+ $startI 1))))
+            ($flatDs (foldl-atom $changeDs () $acc $changeD (append $changeD $acc)))
+            ($final (append $changeRest $flatDs))
+          )
+          (filter-atom $final isNotUnit))))))
+
+;; Fast path for dist=1: flat iteration over positions, no recursive
+;; list-of-lists construction. Matches varyNKnobsDist1 pattern.
+(= (varyNKnobsBySpecListsDist1 $specLists $instExp $startI)
+   (if (>= $startI (length $instExp))
+       ()
+       (let*
+         (
+           ($specs (List.getByIdx $specLists $startI))
+           ($currentVariations (map-atom $specs $m (changeAt $m $startI $instExp)))
+           ($restVariations (varyNKnobsBySpecListsDist1 $specLists $instExp (+ $startI 1)))
+           ($final (append $currentVariations $restVariations))
          )
          (filter-atom $final isNotUnit))))
 
@@ -91,18 +129,58 @@
 ;;   $instExp: The center instance as an expression of numbers
 ;;   $dist: The hamming distance
 
-(= (varyNKnobs $multips $instExp $dist) (varyNKnobs $multips $instExp $dist 0))
-(= (varyNKnobs $multips $instExp $dist $startI)
+;; Previous implementation: generated instances at all distances 1..dist.
+;; Preserved for reference; renamed to avoid confusion with the corrected version.
+(= (varyNKnobsAllDistances $multips $instExp $dist) (varyNKnobsAllDistances $multips $instExp $dist 0))
+(= (varyNKnobsAllDistances $multips $instExp $dist $startI)
    (if (or (== $dist 0) (== $startI (length $instExp)))
        ()
        (let*
          (
            ($changeIs (map-atom $multips $m (changeAt $m $startI $instExp)))
-           ($changeRest (varyNKnobs $multips $instExp $dist (+ $startI 1)))
-           ($changeDs (map-atom $changeIs $changeI (varyNKnobs $multips $changeI (- $dist 1) (+ $startI 1))))
+           ($changeRest (varyNKnobsAllDistances $multips $instExp $dist (+ $startI 1)))
+           ($changeDs (map-atom $changeIs $changeI (varyNKnobsAllDistances $multips $changeI (- $dist 1) (+ $startI 1))))
            ($flatDs (foldl-atom $changeDs () $acc $changeD (append $changeD $acc)))
            ($acc (append $changeIs $changeRest))
            ($final (append $acc $flatDs))
+         )
+         (filter-atom $final isNotUnit))))
+
+;; Corrected implementation matching C++ vary_n_knobs semantics.
+;; Generates instances at EXACTLY the target distance by only recording
+;; the instance when dist == 0 (all modifications consumed), removing
+;; the $changeIs (single-position variations) from the output, and
+;; keeping only $changeDs (multi-position recursive variations).
+;; The base case returns the instance itself when dist == 0,
+;; and the dead end (startI >= length) returns () for unresolvable paths.
+(= (varyNKnobs $multips $instExp $dist) (varyNKnobs $multips $instExp $dist 0))
+(= (varyNKnobs $multips $instExp $dist $startI)
+   (case ($dist (>= $startI (length $instExp)))
+     (
+       ((0 $_) ($instExp))
+       ((1 $_) (varyNKnobsDist1 $multips $instExp $startI))
+       (($dist True) ())
+       (($dist False)
+        (let*
+          (
+            ($changeRest (varyNKnobs $multips $instExp $dist (+ $startI 1)))
+            ($changeDs (map-atom $multips $m (varyNKnobs $multips (changeAt $m $startI $instExp) (- $dist 1) (+ $startI 1))))
+            ($flatDs (foldl-atom $changeDs () $acc $changeD (append $changeD $acc)))
+            ($final (append $changeRest $flatDs))
+          )
+          (filter-atom $final isNotUnit))))))
+
+;; Fast path for dist=1: flat iteration over positions, no recursive
+;; list-of-lists construction. Analogous to C++ UNROLL_TAIL_CALL /
+;; UNROLL_TAIL_CALL_DISC macros (neighborhood_sampling.h:359-389,417-434).
+(= (varyNKnobsDist1 $multips $instExp $startI)
+   (if (>= $startI (length $instExp))
+       ()
+       (let*
+         (
+           ($currentVariations (map-atom $multips $m (changeAt $m $startI $instExp)))
+           ($restVariations (varyNKnobsDist1 $multips $instExp (+ $startI 1)))
+           ($final (append $currentVariations $restVariations))
          )
          (filter-atom $final isNotUnit))))
 

--- a/moses/tests/neighborhood-sampling-test.metta
+++ b/moses/tests/neighborhood-sampling-test.metta
@@ -27,30 +27,73 @@
 
 
 ;; Test case to make sure it varyNKnobs generates unique and all available neighbors.
+;; After Fix 1: varyNKnobs now generates instances at EXACTLY the target distance,
+;; matching C++ vary_n_knobs semantics. C(4,2)*2^2 = 24 for multips=(2 1), dist=2.
 !(assertEqual (let*
                 (
                   ($original (varyNKnobs (2 1) (0 0 0 1) 2))
                   ($unique (unique-atom (varyNKnobs (2 1) (0 0 0 1) 2))))
-                (and (== (length $original) (length $unique)) (== (length $original) 32))) true)
+                (and (== (length $original) (length $unique)) (== (length $original) 24))) true)
 
-;; At distance 2 should generate total of 32 neighbors
-;; !(assertEqual (let $a (generateAllInNeighborhood (mkMultip 3) (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))) 2) ((List.length $a) (get-type $a))) (32 (List Instance)))
-!(assertEqual (let $a (generateAllInNeighborhood (mkMultip 3) (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))) 2) (List.length $a)) 32) ;; Since the type system isn't working properly the above has been replaced with this test case. Change when type starts working correctly.
+;; At distance 2 should generate total of 24 neighbors (exactly dist=2)
+;; C(4,2)*2^2 = 24 after Fix 1 (was 32 when cumulative 1..dist)
+;; !(assertEqual (let $a (generateAllInNeighborhood (mkMultip 3) (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))) 2) ((List.length $a) (get-type $a))) (24 (List Instance)))
+!(assertEqual (let $a (generateAllInNeighborhood (mkMultip 3) (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))) 2) (List.length $a)) 24) ;; Since the type system isn't working properly the above has been replaced with this test case. Change when type starts working correctly.
 ;; !(assertEqual (let $a (generateAllInNeighborhood (mkMultip 3) (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))) 1) ((List.length $a) (get-type $a))) (8 (List Instance)))
 !(assertEqual (let $a (generateAllInNeighborhood (mkMultip 3) (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))) 1) (List.length $a)) 8) ;; Since the type system isn't working properly the above has been replaced with this test case. Change when type starts working correctly.
 
-;; At distance 3 should generate total of 64 neighbors
-;; !(assertEqual (let $a (generateAllInNeighborhood (mkMultip 3) (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))) 3) ((List.length $a) (get-type $a))) (64 (List Instance)))
-!(assertEqual (let $a (generateAllInNeighborhood (mkMultip 3) (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))) 3) (List.length $a)) 64) ;; Since the type system isn't working properly the above has been replaced with this test case. Change when type starts working correctly.
+;; At distance 3 should generate total of 32 neighbors (exactly dist=3)
+;; C(4,3)*2^3 = 32 after Fix 1 (was 64 when cumulative 1..dist)
+;; !(assertEqual (let $a (generateAllInNeighborhood (mkMultip 3) (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))) 3) ((List.length $a) (get-type $a))) (32 (List Instance)))
+!(assertEqual (let $a (generateAllInNeighborhood (mkMultip 3) (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))) 3) (List.length $a)) 32) ;; Since the type system isn't working properly the above has been replaced with this test case. Change when type starts working correctly.
 
-;; Generated neighbors should be 32 in length and center shouldn't be member.
+;; Generated neighbors should be 24 in length and center shouldn't be member.
 ;;    Distance 0 indicates a center node being present.
+;; After Fix 1: exactly dist=2 → C(4,2)*2^2 = 24 (was 32 when cumulative)
 !(assertEqual
    (let $distList
         (List.map ((curry distance) (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ())))))) 
                   (generateAllInNeighborhood (mkMultip 3) (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))) 2))
         ((List.length $distList) (List.contains 0 $distList))) 
-   (32 False))
+   (24 False))
+
+;; Verify all generated neighbors are at EXACTLY the target distance
+;; (matching C++ NeighborSamplingUTest.cxxtest assertions).
+;; Uses foldl to check every distance equals the target.
+!(assertEqual
+   (let*
+      (
+        ($center (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))))
+        ($neighbors (generateAllInNeighborhood (mkMultip 3) $center 2))
+        ($dists (List.map ((curry distance') $center) $neighbors))
+        ($allExact (foldl-atom $dists True $acc $d (and $acc (== $d 2))))
+      )
+      ((List.length $dists) $allExact))
+   (24 True))
+
+;; Same check at distance 1
+!(assertEqual
+   (let*
+      (
+        ($center (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))))
+        ($neighbors (generateAllInNeighborhood (mkMultip 3) $center 1))
+        ($dists (List.map ((curry distance') $center) $neighbors))
+        ($allExact (foldl-atom $dists True $acc $d (and $acc (== $d 1))))
+      )
+      ((List.length $dists) $allExact))
+   (8 True))
+
+;; Same check at distance 3
+!(assertEqual
+   (let*
+      (
+        ($center (mkInst (cons 0 (cons 0 (cons 0 (cons 0 ()))))))
+        ($neighbors (generateAllInNeighborhood (mkMultip 3) $center 3))
+        ($dists (List.map ((curry distance') $center) $neighbors))
+        ($allExact (foldl-atom $dists True $acc $d (and $acc (== $d 3))))
+      )
+      ((List.length $dists) $allExact))
+   (32 True))
 
 (= (tree1)
         (mkTree (mkNode AND)

--- a/optimization/hillclimbing/hill-climbing-helpers.metta
+++ b/optimization/hillclimbing/hill-climbing-helpers.metta
@@ -86,29 +86,48 @@
 ;; Returns:
 ;;   Count of instances at distance $dist from $inst
 
-; a helper function to the countNeighborhood method
+;; Count combinations at one exact distance from the current instance.
+;; The distance-zero result represents the unchanged instance and the index
+;; guard prevents recursive calls from reading beyond the final knob.
 ;; (: countNeighborhoodFromIdx (-> KnobMap Instance Number Number Number Number))
 (= (countNeighborhoodFromIdx (mkKbMap (mkDscMp $dscMp)) $inst $dist $startIdx $maxCount)
-   (let*
-     (
-       (($kbSpec $knob) (MultiMap.getByIdx $startIdx $dscMp))
-       ((mkMultip $multip) (getKnobMultip $knob))
-       ($isBoolTail (and (== $multip 2) (allBooleanKnobs (mkKbMap (mkDscMp $dscMp)) (+ $startIdx 1))))
-     )
-     (case ($dist (>= $startIdx (MultiMap.length $dscMp)) $isBoolTail)
-       (
-         ((0 $_ $_) 1)
-         (($dist True $_) 0)
-         (($dist False True)
-          (let* (($n (- (MultiMap.length $dscMp) $startIdx)))
-            (if (> $dist $n) 
-              0
-              (let $count (binomial $n $dist) (if (> $count $maxCount) $maxCount $count)))))
-         (($dist False False)
-          (let $updatedNumInstances (countNeighborhoodFromIdx (mkKbMap (mkDscMp $dscMp)) $inst $dist (+ $startIdx 1) $maxCount)
-            (if (> $updatedNumInstances $maxCount)
-                $updatedNumInstances
-                (+ $updatedNumInstances (* (- $multip 1) (countNeighborhoodFromIdx (mkKbMap (mkDscMp $dscMp)) $inst (- $dist 1) (+ $startIdx 1) $maxCount))))))))))
+   (if (== $dist 0)
+       1
+       (if (>= $startIdx (MultiMap.length $dscMp))
+           0
+           (let*
+             (
+               (($kbSpec $knob) (MultiMap.getByIdx $startIdx $dscMp))
+               ((mkMultip $multip) (getKnobMultip $knob))
+               ;; A Boolean-only suffix has a direct binomial count, avoiding
+               ;; the per-knob recursion used for mixed-multiplicity maps.
+               ($isBoolTail
+                 (and (== $multip 2)
+                      (allBooleanKnobs
+                        (mkKbMap (mkDscMp $dscMp)) (+ $startIdx 1))))
+             )
+             (if $isBoolTail
+                 (let* (($n (- (MultiMap.length $dscMp) $startIdx)))
+                   ;; Distances beyond the remaining Boolean dimensions are
+                   ;; impossible; otherwise cap the count for callers that
+                   ;; only need a bounded neighborhood estimate.
+                   (if (> $dist $n)
+                       0
+                       (let $count (binomial $n $dist)
+                         (if (> $count $maxCount) $maxCount $count))))
+                 ;; For mixed knobs, skip or change the current knob and add
+                 ;; the resulting counts from the remaining dimensions.
+                 (let $updatedNumInstances
+                            (countNeighborhoodFromIdx
+                              (mkKbMap (mkDscMp $dscMp)) $inst $dist
+                              (+ $startIdx 1) $maxCount)
+                   (if (> $updatedNumInstances $maxCount)
+                       $updatedNumInstances
+                       (+ $updatedNumInstances
+                          (* (- $multip 1)
+                             (countNeighborhoodFromIdx
+                               (mkKbMap (mkDscMp $dscMp)) $inst
+                               (- $dist 1) (+ $startIdx 1) $maxCount))))))))))
 
 ;; Helper: check if all knobs from $startIdx onward have multiplicity 2 (boolean).
 (= (allBooleanKnobs (mkKbMap (mkDscMp ())) $startIdx) True)

--- a/optimization/hillclimbing/hill-climbing-helpers.metta
+++ b/optimization/hillclimbing/hill-climbing-helpers.metta
@@ -17,8 +17,8 @@
 ;; A native fold remains compositional when the estimator consumes the result
 ;; as a nested expression under PeTTa.
 (= (informationTheoreticBits $knobMap)
-   (foldl-atom (MultiMap.values $knobMap) 0 $bits $knob
-     (+ $bits (knobInformationBits $knob))))
+   (floor-math (foldl-atom (MultiMap.values $knobMap) 0 $bits $knob
+     (+ $bits (knobInformationBits $knob)))))
 
 ;; feature selection version of the informationTheoreticBits function
 ;; In the case of feature selection, the information theoretic bits is simply the number of features we have
@@ -89,20 +89,34 @@
 ; a helper function to the countNeighborhood method
 ;; (: countNeighborhoodFromIdx (-> KnobMap Instance Number Number Number Number))
 (= (countNeighborhoodFromIdx (mkKbMap (mkDscMp $dscMp)) $inst $dist $startIdx $maxCount)
-(if (== $dist 0)
-    1
-    (if (>= $startIdx (MultiMap.length $dscMp))
-        0
-        (let $updatedNumInstances (countNeighborhoodFromIdx (mkKbMap (mkDscMp $dscMp)) $inst $dist (+ $startIdx 1) $maxCount)
-          (if  (> $updatedNumInstances $maxCount)
-               $updatedNumInstances
-               (let*
-                 (
-                    (($kbSpec $knob) (MultiMap.getByIdx $startIdx $dscMp))
-                    ((mkMultip $multip) (getKnobMultip $knob))
-                    ($uUpdatedNumInstances (+ $updatedNumInstances (* (- $multip 1) (countNeighborhoodFromIdx (mkKbMap (mkDscMp $dscMp)) $inst (- $dist 1) (+ $startIdx 1) $maxCount))))
-                 )
-                 $uUpdatedNumInstances))))))
+   (let*
+     (
+       (($kbSpec $knob) (MultiMap.getByIdx $startIdx $dscMp))
+       ((mkMultip $multip) (getKnobMultip $knob))
+       ($isBoolTail (and (== $multip 2) (allBooleanKnobs (mkKbMap (mkDscMp $dscMp)) (+ $startIdx 1))))
+     )
+     (case ($dist (>= $startIdx (MultiMap.length $dscMp)) $isBoolTail)
+       (
+         ((0 $_ $_) 1)
+         (($dist True $_) 0)
+         (($dist False True)
+          (let* (($n (- (MultiMap.length $dscMp) $startIdx)))
+            (if (> $dist $n) 
+              0
+              (let $count (binomial $n $dist) (if (> $count $maxCount) $maxCount $count)))))
+         (($dist False False)
+          (let $updatedNumInstances (countNeighborhoodFromIdx (mkKbMap (mkDscMp $dscMp)) $inst $dist (+ $startIdx 1) $maxCount)
+            (if (> $updatedNumInstances $maxCount)
+                $updatedNumInstances
+                (+ $updatedNumInstances (* (- $multip 1) (countNeighborhoodFromIdx (mkKbMap (mkDscMp $dscMp)) $inst (- $dist 1) (+ $startIdx 1) $maxCount))))))))))
+
+;; Helper: check if all knobs from $startIdx onward have multiplicity 2 (boolean).
+(= (allBooleanKnobs (mkKbMap (mkDscMp ())) $startIdx) True)
+(= (allBooleanKnobs (mkKbMap (mkDscMp (cons ($spec $knob) $tail))) $startIdx)
+   (let (mkMultip $multip) (getKnobMultip $knob)
+     (if (== $multip 2)
+         (allBooleanKnobs (mkKbMap (mkDscMp $tail)) (+ $startIdx 1))
+         False)))
 
 ; countNeighborhood
 ;; (: countNeighborhood (-> KnobMap Instance Number Number Number))

--- a/optimization/hillclimbing/test/hillclimbing-helpers-test.metta
+++ b/optimization/hillclimbing/test/hillclimbing-helpers-test.metta
@@ -77,13 +77,13 @@
 ;; map containing two knobs with same multiplicity of 3
 !(assertEqual
   (informationTheoreticBits (knobmap1))
-  (+ (log-math 2 3) (log-math 2 3)))
+  3)
 
 ;; Test informationTheoreticBits with a knob
 ;; map containing two knobs with different multiplicity of 2 and 3
 !(assertEqual
   (informationTheoreticBits (knobmap2))
-  (+ (log-math 2 2) (log-math 2 3)))
+  2)
 
 ;; Testcase for informationTheoreticBitsFs
 !(assertEqual


### PR DESCRIPTION
## Description
This PR aligns MeTTa neighborhood sampling and neighborhood counting behavior with the corresponding C++ MOSES semantics, particularly around distance handling and exact neighborhood sizes.

## Changes
### Neighborhood Sampling
Updated varyNKnobs to correctly return the center expression when dist == 0.
Changed sampling behavior so that each distance produces only variations involving exactly that number of changed positions, matching the behavior of C++ vary_n_knobs.
Added optimized fast paths for dist = 1.
Renamed the previous all-distance behavior to varyNKnobsAllDistances.
### Neighborhood Counting
Updated countNeighborhoodFromIdx to follow the corrected distance semantics.
Added a boolean-only tail optimization using the binomial coefficient for efficient neighborhood counting.
Replaced nested conditional logic with case-based dispatch.
Updated informationTheoreticBits to return floored values where required.

## Tests
Updated neighborhood sampling expectations:
dist = 2 → 24 variations
dist = 3 → 32 variations
Added assertions verifying that generated variations are at exactly the requested distance.
Updated hill-climbing helper tests to reflect the _floored_ `informationTheoreticBits `behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
